### PR TITLE
build(log): restore logging

### DIFF
--- a/src/iso-registry-client/pom.xml
+++ b/src/iso-registry-client/pom.xml
@@ -37,6 +37,7 @@
 		<gml.identifier.baseurl></gml.identifier.baseurl>		
 		<gml.identifier.pathpattern>register/geodetic/items/%d</gml.identifier.pathpattern>
 		<register.aliases>geodetic:ISO Geodetic Register</register.aliases>
+		<slf4j.scope>provided</slf4j.scope>
 	</properties>
 	<dependencies>
 		<!-- Spring -->
@@ -75,36 +76,36 @@
 			<version>${org.slf4j-version}</version>
 			<scope>runtime</scope>
 		</dependency>
-<!--		<dependency>-->
-<!--			<groupId>org.slf4j</groupId>-->
-<!--			<artifactId>slf4j-log4j12</artifactId>-->
-<!--			<version>${org.slf4j-version}</version>-->
-<!--			<scope>runtime</scope>-->
-<!--		</dependency>-->
-<!--		<dependency>-->
-<!--			<groupId>log4j</groupId>-->
-<!--			<artifactId>log4j</artifactId>-->
-<!--			<version>1.2.15</version>-->
-<!--			<exclusions>-->
-<!--				<exclusion>-->
-<!--					<groupId>javax.mail</groupId>-->
-<!--					<artifactId>mail</artifactId>-->
-<!--				</exclusion>-->
-<!--				<exclusion>-->
-<!--					<groupId>javax.jms</groupId>-->
-<!--					<artifactId>jms</artifactId>-->
-<!--				</exclusion>-->
-<!--				<exclusion>-->
-<!--					<groupId>com.sun.jdmk</groupId>-->
-<!--					<artifactId>jmxtools</artifactId>-->
-<!--				</exclusion>-->
-<!--				<exclusion>-->
-<!--					<groupId>com.sun.jmx</groupId>-->
-<!--					<artifactId>jmxri</artifactId>-->
-<!--				</exclusion>-->
-<!--			</exclusions>-->
-<!--			<scope>runtime</scope>-->
-<!--		</dependency>-->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-log4j12</artifactId>
+			<version>${org.slf4j-version}</version>
+			<scope>${slf4j.scope}</scope>
+		</dependency>
+		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.15</version>
+			<exclusions>
+				<exclusion>
+					<groupId>javax.mail</groupId>
+					<artifactId>mail</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>javax.jms</groupId>
+					<artifactId>jms</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jdmk</groupId>
+					<artifactId>jmxtools</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.sun.jmx</groupId>
+					<artifactId>jmxri</artifactId>
+				</exclusion>
+			</exclusions>
+			<scope>${slf4j.scope}</scope>
+		</dependency>
 
 		<!-- @Inject -->
 		<dependency>
@@ -470,6 +471,7 @@
 				<client.signup.sendConfirmationMails>false</client.signup.sendConfirmationMails>
 				<client.signup.confirmationUrl>http://localhost:8080/signup/confirmation</client.signup.confirmationUrl>
 				<gml.identifier.baseurl>http://localhost:8080</gml.identifier.baseurl>		
+				<slf4j.scope>runtime</slf4j.scope>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
This restores the dependency to SLF4J that was removed in commit f975fff as this breaks logging in environments where log4j is not available in the servlet container.

To accomodate environments that do provide log4j as part of the servlet container, the POM property `slf4j.scope` is introduced that can be set to `provided` in build profiles targeting those environments.