### PR TITLE
Fix deletion of returned proposals and visibility of Delete action

### DIFF
--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/IsoProposalServiceImpl.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/IsoProposalServiceImpl.java
@@ -257,6 +257,7 @@ public class IsoProposalServiceImpl extends ProposalServiceImpl implements IsoPr
 		
 		List<RE_RegisterItem> itemsToDelete = new ArrayList<>();
 		List<RE_ProposalManagementInformation> pmisToDelete = new ArrayList<>();
+		List<ProposalNote> notesToDelete = new ArrayList<>();
 		
 		for (RE_ProposalManagementInformation pmi : proposal.getProposalManagementInformations()) {
 			if (pmi.getItem() != null && RE_ItemStatus.NOT_VALID.equals(pmi.getItem().getStatus())) {
@@ -268,9 +269,18 @@ public class IsoProposalServiceImpl extends ProposalServiceImpl implements IsoPr
 			pmisToDelete.add(pmi);
 		}
 		
+		for (ProposalNote note : noteRepository.findByProposal(proposal)) {
+			note.setProposal(null);
+			notesToDelete.add(note);
+		}
+
 		proposal.delete();
 		repository().delete(proposal);
 		
+		for (ProposalNote note : notesToDelete) {
+			noteRepository.delete(note);
+		}
+
 		for (RE_ProposalManagementInformation pmi : pmisToDelete) {
 			pmiRepository.delete(pmi);
 		}

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/manager.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/manager.html
@@ -331,9 +331,6 @@
 							  actions += endAppealPopup(full);
 						  }
 						  
-						  dropdownActions.push(deleteButton(full));
-						  actions += deletePopup(full);
-
 						  actions += dropdownMenu(full.proposalUuid, dropdownActions);
 						  
 						  return actions;


### PR DESCRIPTION
This fixes a problem where proposals that were previously returned to the submitter either by the Register Manager or the Control Body could not be deleted

Returning the proposal resulted in a `ProposalNote` being attached to the proposal which subsequently blocked deletion of the `Proposal` object on a database level due to a foreign key relationship. This is addressed by unlinking `ProposalNotes` before deleting them and the `Proposal`.

Also fixes the problem where using the `Delete` action as a Register Manager on a submitted proposal up for review resulted in an error. The error was thrown because proposals may not be deleted once submitted (only withdrawn). Therefore, the `Delete` action is no longer shown once a proposal is submitted.