### PR TITLE
Fix editors for coordinate operations

### DIFF
--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/SingleOperationItemProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/SingleOperationItemProposalDTO.java
@@ -246,16 +246,22 @@ public class SingleOperationItemProposalDTO extends CoordinateOperationItemPropo
 			else if (paramValue instanceof Collection) {
 				throw new UnsupportedOperationException("Parameter lists are not yet supported");
 			}
+
 			ParameterValueDTO value;
 			if (uom == null) {
 				OperationParameterItemProposalDTO a = new OperationParameterItemProposalDTO(opv.getParameter());
-				value = new ParameterValueDTO(a, opv.getParameterType(), paramValue.toString());
+				value = new ParameterValueDTO(a, opv.getParameterType(), paramValue == null ? null : paramValue.toString());
 			}
 			else {
 				OperationParameterItemProposalDTO a = new OperationParameterItemProposalDTO(opv.getParameter());
-				value = new ParameterValueDTO(a, paramValue.toString(), new UnitOfMeasureItemProposalDTO(uom));
+				value = new ParameterValueDTO(a, paramValue == null ? null : paramValue.toString(), new UnitOfMeasureItemProposalDTO(uom));
 			}
-	
+
+			if (opv.getReferenceFileCitation() != null) {
+				CitationDTO valueFileCitation = new CitationDTO(opv.getReferenceFileCitation());
+				value.setValueFileCitation(valueFileCitation);
+			}
+
 			this.parameterValues.add(value);
 		}
 	}

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
@@ -102,10 +102,9 @@
 						<th th:text="#{tableheader.parameter}">Parameter</th>
 						<th th:text="#{tableheader.value}">Value</th>
 						<th th:text="#{tableheader.uom}">UoM</th>
-						<th th:text="#{tableheader.citation}">Citation</th>
 					</tr>
 				</thead>
-				<tbody>
+				<tbody th:unless="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
 						<td th:text="${parameterValue.parameterName}"></td>
 						<td>
@@ -114,15 +113,24 @@
 							</div>
 						</td>
 						<td>
-							<input th:if="${isProposal}" type="hidden" th:id="'paramValue_' + ${row.index}" class="select-uom" th:value="${parameterValue.uomUuid}" required="required" style="width: 100%"/>
 							<a th:unless="${isProposal} or !${parameterValue.unitOfMeasure}" th:href="@{__${basePath}__/item/__${parameterValue.unitOfMeasure.uuid}__}" th:text="${parameterValue.unitOfMeasure.name} + ' [' + ${parameterValue.unitOfMeasure.identifier} + ']'"></a>
-						</td>							
+						</td>
+					</tr>
+				</tbody>
+				<tbody th:if="${isProposal}">
+					<tr th:each="parameterValue,row : *{parameterValues}">
 						<td>
-							<div th:if="${parameterValue.referenceFileCitation}" th:with="citation=${parameterValue.referenceFileCitation}"> 
-								<a th:id="'citation-' + ${row.index}" th:href="'#dialog-citation-' + ${row.index}" data-toggle="modal" th:text="${parameterValue.referenceFileCitation.title} ? ${parameterValue.referenceFileCitation.title} : ('[' + #{untitled} + ']')"/>
-								<div th:replace="registry/registers/gcp/infosrc_panel :: citationPopup(${row.index})"/>
+							<span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span>
+							<input type="hidden" th:name="'parameterValues[' + ${row.index} + '].parameter.referencedItemUuid'" th:value="${parameterValue.parameter.referencedItemUuid}"/>
+						</td>
+						<td>
+							<div class="form-group">
+								<input type="text" class="form-control required" th:id="'parameter-value-' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].value'" th:value="${parameterValue.value}" th:disabled="${proposal.isClarification()}" th:readonly="${proposal.isClarification()}" th:required="!${proposal.isClarification()}"/>
 							</div>
-						</td>							
+						</td>
+						<td>
+							<input type="hidden" th:id="'parameterUom_' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].parameterUnit.referencedItemUuid'" class="select-uom" th:value="${parameterValue.parameterUnit?.referencedItemUuid}" required="required" style="width: 100%"/>
+						</td>
 					</tr>
 				</tbody>
 			</table>
@@ -199,9 +207,9 @@
             	.done(function (data) {
             		$.each(data, function(idx, item) {
         				table.fnAddData([
-        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameterUuid' value='" + item[0] + "'/>",
+        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
         					"<div class='form-group'><input type='text' class='form-control input-sm col-md-12' name='parameterValues[" + idx + "].value' required='required'/></div>",
-    						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].uomUuid' required='required' style='width: 100%'/>"
+    						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].parameterUnit.referencedItemUuid' required='required' style='width: 100%'/>"
 						]);
         				uomSelect($('#parameterUom_' + idx));
             		});

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel.html
@@ -39,7 +39,7 @@
 				
 				$('<div id="infosrc-' + idx + '" class="tab-pane" style="padding-top: 10px"/>').insertBefore('#afterTabs');
 				$('#infosrc-' + idx).append('<div id="infosrc-' + idx + '-content" class="panel-body"/>');
-				$('#infosrc-' + idx + '-content').load('[[@{__${basePath}__/entities/fragments/informationsource}]]?index=' + idx + '&objectPath=informationSource[' + idx + ']', null, function() {
+				$('#infosrc-' + idx + '-content').load('[[@{__${basePath}__/entities/fragments/informationsource}]]?index=' + idx + '&objectPath=informationSource%5B' + idx + '%5D', null, function() {
 				    $("#publicationDate-informationSource-" + idx).rules("add", {
 				    	required: '#revisionDate-informationSource-' + idx + ':blank',
 // 				   	    required: function(element) {
@@ -111,10 +111,26 @@
 			<div class="modal-header">
 				<h4 th:text="#{popup.informationSource.header}"></h4>
 			</div>
-			<div th:unless="${isProposal}" class="modal-body" th:object="${citation}">
+			<div th:unless="${isProposal}" class="modal-body" th:object="${citation}" th:with="isReadOnly='true'">
 				<div th:include="registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(${index})"/>
 			</div>
-			<div th:if="${isProposal}" class="modal-body" th:object="${citation}" th:with="isReadOnly='true'">
+			<div th:if="${isProposal}" class="modal-body" th:object="${citation}">
+				<div th:include="registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(${index})"/>
+			</div>
+			<div class="modal-footer">
+				<button type="button" id="infosrcPopup_ok" class="btn btn-default" data-dismiss="modal" th:text="#{button.ok}">Ok</button>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div th:fragment="citationPopupValueReference(index)" class="modal fade" th:id="'dialog-citation-' + ${index}" role="dialog">
+	<div class="modal-dialog modal-lg">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h4 th:text="#{popup.informationSource.header}"></h4>
+			</div>
+			<div class="modal-body" th:object="${proposal.parameterValues[__${index}__].valueFileCitation}" th:with="altTitlePrefix='parameterValues[' + ${index} + '].valueFileCitation'">
 				<div th:include="registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(${index})"/>
 			</div>
 			<div class="modal-footer">

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel_content.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel_content.html
@@ -67,18 +67,20 @@
 		</div>
 	</div>
 	<div th:class="'alternate-title-row-' + ${index}" th:attr="data-count=${objectPath} ? '0' : *{alternateTitle.size()}"/>
-	<div th:unless="${objectPath}" th:each="altTitle,rowStat : *{alternateTitle}" th:id="'altTitleRow-' + ${rowStat.index}" class="row alternate-title-row">
-		<div class="form-group col-md-12">
-			<div th:replace="globals :: formLabel('alternateTitle-' + ${rowStat.index}, #{form.label.alternateTitle})"/>
-			<div class="input-group">
-				<input th:if="${isProposal}" th:name="'informationSource[__${index}__].alternateTitle[' + ${rowStat.index} + ']'" th:value="${altTitle}" class="form-control"/>
-				<span th:unless="${isProposal}" class="text-muted" th:text="${rowStat.index + 1} + '.'"></span>&nbsp;<big th:unless="${isProposal}" th:text="${altTitle}"/>
-				<span class="input-group-btn" th:if="${isProposal}">
-					<button type="button" class="btn btn-default button-delete-alt-title" th:id="'delete-alt-title-' + ${rowStat.index}"><span class="glyphicon glyphicon-remove"/></button>
-				</span>
+	<th:block th:unless="${objectPath}">
+		<div th:each="altTitle,rowStat : *{alternateTitle}" th:id="'altTitleRow-' + ${rowStat.index}" class="row alternate-title-row">
+			<div class="form-group col-md-12">
+				<div th:replace="globals :: formLabel('alternateTitle-' + ${rowStat.index}, #{form.label.alternateTitle})"/>
+				<div class="input-group">
+					<input th:if="${isProposal}" th:name="'informationSource[__${index}__].alternateTitle[' + ${rowStat.index} + ']'" th:value="${altTitle}" class="form-control"/>
+					<span th:unless="${isProposal}" class="text-muted" th:text="${rowStat.index + 1} + '.'"></span>&nbsp;<big th:unless="${isProposal}" th:text="${altTitle}"/>
+					<span class="input-group-btn" th:if="${isProposal}">
+						<button type="button" class="btn btn-default button-delete-alt-title" th:id="'delete-alt-title-' + ${rowStat.index}"><span class="glyphicon glyphicon-remove"/></button>
+					</span>
+				</div>
 			</div>
 		</div>
-	</div>
+	</th:block>
 	<div th:if="${isProposal}" th:unless="${isReadOnly}" class="row">
 		<div class="form-group col-md-4">
 			<button th:id="'addAlternateTitle-' + ${index}" type="button" th:attr="data-index=${index}" class="btn btn-default button-add-alternate-title" th:text="#{button.addAlternateTitle}"/>
@@ -153,7 +155,12 @@
 			$('body').on('click', '.button-add-alternate-title', function() {
 				var idx = $(this).data('index');
 				var count = $('.alternate-title-row-' + idx).data('count');
-				$('.alternate-title-row-' + idx).last().after("<div class='row alternate-title-row'><div class='form-group col-md-12'><div class='control-label' for='alternateTitle'><label class='control-label' for='alternateTitle'><span>[[#{form.label.alternateTitle}]]</span></label></div><div class='input-group'><input class='form-control' name='informationSource[" + idx + "].alternateTitle[" + count + "]' value=''/><span class='input-group-btn'><button type='button' class='btn btn-default button-delete-alt-title' id='delete-alt-title-" + count + "'><span class='glyphicon glyphicon-remove'/></button></span></div></div></div>");
+				if ([[${altTitlePrefix} ? 'true' : 'false']]) {
+					$('.alternate-title-row-' + idx).last().after("<div class='row alternate-title-row'><div class='form-group col-md-12'><div class='control-label' for='alternateTitle'><label class='control-label' for='alternateTitle'><span>[[#{form.label.alternateTitle}]]</span></label></div><div class='input-group'><input class='form-control' name='[[${altTitlePrefix}]].alternateTitle[" + count + "]' value=''/><span class='input-group-btn'><button type='button' class='btn btn-default button-delete-alt-title' id='delete-alt-title-" + count + "'><span class='glyphicon glyphicon-remove'/></button></span></div></div></div>");
+				}
+				else {
+					$('.alternate-title-row-' + idx).last().after("<div class='row alternate-title-row'><div class='form-group col-md-12'><div class='control-label' for='alternateTitle'><label class='control-label' for='alternateTitle'><span>[[#{form.label.alternateTitle}]]</span></label></div><div class='input-group'><input class='form-control' name='informationSource[" + idx + "].alternateTitle[" + count + "]' value=''/><span class='input-group-btn'><button type='button' class='btn btn-default button-delete-alt-title' id='delete-alt-title-" + count + "'><span class='glyphicon glyphicon-remove'/></button></span></div></div></div>");
+				}
 				$('.alternate-title-row-' + idx).data('count', ++count);
 			});
 			

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
@@ -121,32 +121,52 @@
 						<th th:text="#{tableheader.citation}">Citation</th>
 					</tr>
 				</thead>
-				<tbody>
+				<tbody th:unless="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
 						<td th:text="${parameterValue.parameterName}"></td>
 						<td>
-							<input th:if="${isProposal}" type="hidden" th:id="'paramValueType_' + ${row.index}" th:attr="data-index=${row.index}" class="select-paramtype" th:value="${parameterValue.parameterType}" required="required" th:readonly="${proposal.isClarification()}" style="width: 100%"/>
-							<input th:unless="${isProposal}" type="hidden" th:id="'paramValueType_' + ${row.index}" th:attr="data-index=${row.index}" class="select-paramtype" th:value="${parameterValue.parameterType}" readonly="readonly" style="width: 100%"/>
+							<input type="hidden" th:id="'paramValueType_' + ${row.index}" th:attr="data-index=${row.index}" class="select-paramtype" th:value="${parameterValue.parameterType}" readonly="readonly" style="width: 100%"/>
 						</td>
 						<td>
-							<div class="form-group" th:if="${isProposal}">
-								<input type="text" class="form-control input-sm required" th:value="${parameterValue.value}" th:disabled="${proposal.isClarification()}" th:readonly="${proposal.isClarification()}" th:required="!${proposal.isClarification()}"/>
-							</div>
-							<span th:unless="${isProposal}" th:text="${parameterValue.value}"></span>
+							<span th:text="${parameterValue.value}"></span>
 						</td>
 						<td th:with="isMeasure=(${parameterValue.parameterType} eq 'MEASURE')">
-							<input th:if="${isProposal}" type="hidden" th:id="'parameterUom_' + ${row.index}" class="select-uom" th:value="${parameterValue.parameterUnit.uuid}" th:disabled="!${isMeasure} or ${proposal.isClarification()}" th:required="${isMeasure}" style="width: 100%"/>
-							<a th:unless="${isProposal} or !${parameterValue.unitOfMeasure}" th:href="@{__${basePath}__/item/__${parameterValue.unitOfMeasure.uuid}__}" th:text="${parameterValue.unitOfMeasure.name}"></a>&nbsp;<span th:unless="${isProposal} or !${parameterValue.unitOfMeasure}" class="text-muted" th:text="'[' + ${parameterValue.unitOfMeasure.identifier} + ']'"></span>
+							<a th:unless="!${parameterValue.unitOfMeasure}" th:href="@{__${basePath}__/item/__${parameterValue.unitOfMeasure.uuid}__}" th:text="${parameterValue.unitOfMeasure.name}"></a>&nbsp;<span th:unless="${isProposal} or !${parameterValue.unitOfMeasure}" class="text-muted" th:text="'[' + ${parameterValue.unitOfMeasure.identifier} + ']'"></span>
 						</td>							
 						<td th:with="isFile=(${parameterValue.parameterType} eq 'FILE')">
-							<div th:if="${isProposal}">
-								<a th:id="'citation-' + ${row.index}" th:href="'#dialog-citation-' + ${row.index}" data-toggle="modal" th:text="#{button.edit}"/>
-								<div th:replace="registry/registers/gcp/infosrc_panel :: citationPopup(${row.index})"/>
-							</div>
-							<div th:unless="${isProposal}" th:if="${parameterValue.referenceFileCitation}" th:with="citation=${parameterValue.referenceFileCitation}"> 
+							<div th:if="${parameterValue.referenceFileCitation}" th:with="citation=${parameterValue.referenceFileCitation}"> 
 								<a th:id="'citation-' + ${row.index}" th:href="'#dialog-citation-' + ${row.index}" data-toggle="modal" th:text="${parameterValue.referenceFileCitation.title} ? ${parameterValue.referenceFileCitation.title} : ('[' + #{untitled} + ']')"/>
-								<div th:replace="registry/registers/gcp/infosrc_panel :: citationPopup(${row.index})"/>
 							</div>
+						</td>
+						<td th:text="${row.index}"/>			
+					</tr>
+				</tbody>
+				<tbody th:if="${isProposal}">
+					<tr th:each="parameterValue,row : *{parameterValues}">
+						<td>
+							<span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span>
+							<input type="hidden" th:name="'parameterValues[' + ${row.index} + '].parameter.referencedItemUuid'" th:value="${parameterValue.parameter.referencedItemUuid}"/>
+						</td>
+						<td>
+							<input type="hidden" th:id="'paramValueType_' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].parameterType'" th:attr="data-index=${row.index}" class="select-paramtype" th:value="${parameterValue.parameterType}" required="required" th:readonly="${proposal.isClarification()}" style="width: 100%"/>
+						</td>
+						<td>
+							<div class="form-group">
+								<input type="text" class="form-control input-sm required" th:id="'parameter-value-' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].value'" th:value="${parameterValue.value}" th:disabled="${proposal.isClarification()}" th:readonly="${proposal.isClarification()}" th:required="!${proposal.isClarification()}"/>
+							</div>
+						</td>
+						<td th:with="isMeasure=(${parameterValue.parameterType.toString()} eq 'MEASURE')">
+							<input th:if="${isMeasure}" type="hidden" th:id="'parameterUom_' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].parameterUnit.referencedItemUuid'" class="select-uom" th:value="${parameterValue.parameterUnit?.referencedItemUuid}" th:disabled="${parameterValue.parameterType} eq 'MEASURE' or ${proposal.isClarification()}" th:required="${isMeasure}" style="width: 100%"/>
+							<input th:unless="${isMeasure}" type="hidden" th:id="'parameterUom_' + ${row.index}" th:name="'parameterValues[' + ${row.index} + '].parameterUnit.referencedItemUuid'" class="select-uom" th:disabled="disabled" style="width: 100%"/>
+						</td>
+						<td th:with="isFile=(${parameterValue.parameterType.toString()} eq 'FILE')">
+							<th:block th:if="${isFile}">
+								<a th:id="'citation-' + ${row.index}" th:href="'#dialog-citation-' + ${row.index}" data-toggle="modal" th:text="#{button.edit}"/>
+								<div th:id="'x-dialog-citation-' + ${row.index}" th:replace="registry/registers/gcp/infosrc_panel :: citationPopupValueReference(${row.index})"/>
+							</th:block>
+							<th:block th:unless="${isFile}">
+								<a th:id="'citation-' + ${row.index}" th:href="'#dialog-citation-' + ${row.index}" data-toggle="modal"/><div th:id="'x-dialog-citation-' + ${row.index}"/>
+							</th:block>
 						</td>
 						<td th:text="${row.index}"/>			
 					</tr>
@@ -237,28 +257,25 @@
        		
        		$('#parametersTable').on('change', '.select-paramtype', function(e) {
        			var idx = $(this).data('index');
+       			
        			if ($(this).val() == 'MEASURE') {
        				$('#parameterUom_' + idx).removeAttr('disabled');
        				$('#parameterUom_' + idx).select2('enable', true);
        				$('#parameterUom_' + idx).select2('readonly', false);
+       				$('#parameterUom_' + idx).select2('val', '');
        				$('#parameterUom_' + idx).attr('required', 'required');
+       				$('#parameter-value-' + idx).val('');
+    				$('#citation-' + idx).empty();
+    				$('#x-dialog-citation-' + idx).empty();
        			}
        			else {
        				$('#parameterUom_' + idx).val('');
        				$('#parameterUom_' + idx).select2('enable', false);
+       				$('#parameterUom_' + idx).select2('val', '');
        				$('#parameterUom_' + idx).removeAttr('required');
-       			}
-
-       			if ($(this).val() == 'FILE') {
-       				$('#parameterUom_' + idx).removeAttr('disabled');
-       				$('#parameterUom_' + idx).select2('enable', true);
-       				$('#parameterUom_' + idx).select2('readonly', false);
-       				$('#parameterUom_' + idx).attr('required', 'required');
-       			}
-       			else {
-       				$('#parameterUom_' + idx).val('');
-       				$('#parameterUom_' + idx).select2('enable', false);
-       				$('#parameterUom_' + idx).removeAttr('required');
+       				$('#parameter-value-' + idx).val('');
+    				$('#citation-' + idx).text('[[#{button.edit}]]');
+    				$('#x-dialog-citation-' + idx).load('[[@{__${basePath}__/entities/fragments/citationpopup}]]?index=' + idx + '&objectPath=parameterValues%5B' + idx + '%5D.valueFileCitation', null, function() {});
        			}
        		});
 
@@ -271,11 +288,12 @@
             	.done(function (data) {
             		$.each(data, function(idx, item) {
         				table.fnAddData([
-        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameterUuid' value='" + item[0] + "'/>",
+        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
         					"<input type='hidden' id='paramValueType_" + idx + "' data-index='" + idx + "' class='select-paramtype' name='parameterValues[" + idx + "].parameterType' value='MEASURE' required='required' style='width: 100%'/>",
         					"<div class='form-group'><input type='text' class='form-control input-sm col-md-12' name='parameterValues[" + idx + "].value' required='required'/></div>",
-    						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].uomUuid' required='required' style='width: 100%'/>",
-    						"",
+    						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].parameterUnit.referencedItemUuid' required='required' style='width: 100%'/>",
+     						"<a id='citation-" + idx + "' href='#dialog-citation-" + idx + "' data-toggle='modal'></a><div id='x-dialog-citation-" + idx + "'/>",
+							"",
     						idx
 						]);
         				uomSelect($('#parameterUom_' + idx));


### PR DESCRIPTION
Updates `registry-base`  submodule and fixes several issues in the web editors for Transformations and Conversions:

- remove superfluous `Citation` column from parameter table
- fix that parameters get lost when editing and saving a Conversion
- add ability to enter citations for reference file parameters
- add ability to enter Information Source citations
- fix that selected Operation Method is lost when editing and saving a proposal
- fix `NullPointerException` when editing a proposal in cases where a parameter value was missing in the proposal