### PR TITLE
feat: show proposal notes in submitting org's proposal list

### DIFF
--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/ProposalListItemNotesDecorator.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/ProposalListItemNotesDecorator.java
@@ -1,0 +1,48 @@
+package org.iso.registry.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.iso.registry.core.model.ProposalNote;
+import org.iso.registry.core.model.ProposalNoteRepository;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.geoinfoffm.registry.api.ProposalListItem;
+import de.geoinfoffm.registry.api.ProposalListItemDecorator;
+
+public class ProposalListItemNotesDecorator extends ProposalListItemDecorator
+{
+	private final ProposalNoteRepository noteRepository;
+
+	public ProposalListItemNotesDecorator(ProposalListItem decoratee, ProposalNoteRepository noteRepository) {
+		super(decoratee);
+
+		this.noteRepository = noteRepository;
+	}
+
+	@JsonIgnore
+	public List<ProposalNote> getProposalNotes() {
+		return noteRepository.findByProposal(this.getProposal());
+	}
+
+	@Override
+	public Map<String, Object> getAdditionalData() {
+		Map<String, Object> result = super.getAdditionalData();
+
+		List<ProposalNoteViewBean> notes = new ArrayList<>();
+		for (ProposalNote note : this.getProposalNotes()) {
+			notes.add(new ProposalNoteViewBean(note));
+		}
+		result.put("notes", notes);
+
+		return result;
+	}
+
+	@JsonProperty
+	public boolean hasNotes() {
+		return !getProposalNotes().isEmpty();
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/ProposalNoteViewBean.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/ProposalNoteViewBean.java
@@ -1,0 +1,41 @@
+package org.iso.registry.api;
+
+import java.util.UUID;
+
+import org.iso.registry.core.model.ProposalNote;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ProposalNoteViewBean
+{
+	private ProposalNote note;
+
+	public ProposalNoteViewBean(ProposalNote note) {
+		this.note = note;
+	}
+
+	@JsonProperty
+	public UUID getProposalUuid() {
+		return note.getProposal().getUuid();
+	}
+
+	@JsonProperty
+	public String getProposalTitle() {
+		return note.getProposal().getTitle();
+	}
+
+	@JsonProperty
+	public String getNote() {
+		return note.getNote();
+	}
+
+	@JsonProperty
+	public String getAuthorEmail() {
+		return note.getAuthor().getEmailAddress();
+	}
+
+	@JsonProperty
+	public String getAuthorName() {
+		return note.getAuthor().getName();
+	}
+}

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/ManagementController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/ManagementController.java
@@ -3,10 +3,7 @@
  */
 package org.iso.registry.client.controller;
 
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.CONTROLBODY_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.MANAGER_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.POINTOFCONTACT_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.SUBMITTER_ROLE_PREFIX;
+import static de.geoinfoffm.registry.core.security.RegistrySecurity.*;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,7 +14,9 @@ import java.util.UUID;
 
 import javax.validation.Valid;
 
+import org.iso.registry.api.ProposalListItemNotesDecorator;
 import org.iso.registry.client.controller.registry.ProposalNotFoundException;
+import org.iso.registry.core.model.ProposalNoteRepository;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
@@ -130,6 +129,9 @@ public class ManagementController
 
 	@Autowired
 	private ProposalChangeRequestRepository pcrRepository;
+
+	@Autowired
+	private ProposalNoteRepository noteRepository;
 
 	@Autowired
 	private MessageSource messageSource;
@@ -355,7 +357,7 @@ public class ManagementController
 		for (Proposal proposal : proposals) {
 			ProposalListItem rvb = new ProposalListItemImpl(proposal, messageSource, locale, workflowManager, pcrRepository);
 			rvb.setSubmitter(security.hasEntityRelatedRoleForAll(SUBMITTER_ROLE_PREFIX, proposal.getAffectedRegisters()));
-			proposalViewBeans.add(rvb);
+			proposalViewBeans.add(new ProposalListItemNotesDecorator(rvb, noteRepository));
 		}
 		DatatablesResult result = new DatatablesResult(proposals.getTotalElements(), proposals.getTotalElements(), dtParameters.sEcho, proposalViewBeans);
 

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
@@ -525,5 +525,38 @@
 			});
 		});	
 	};
+
+	var showNotesButton = function(item) {
+		return '<a href="#notespopup-' + item.proposalUuid + '" id="notes-' + item.proposalUuid + '" data-toggle="modal" class="action-' + item.proposalUuid + '" data-uuid="' + item.proposalUuid + '"><span class="fa fa-envelope"></span></a>';
+	}
+
+	var notesPopup = function(item) {
+		var result =
+			'<div class="modal fade" id="notespopup-' + item.proposalUuid + '" role="dialog">' +
+				'<div class="modal-dialog">' +
+					'<div class="modal-content">' +
+						'<div class="modal-header">' +
+							'<h4>[[#{popup.proposalNotes.header}]]</h4>' +
+						'</div>' +
+						'<div class="modal-body">';
+		$.each(item.additionalData['notes'], function(idx, note) {
+			result +=
+				'<blockquote>' +
+				  '<p>' + note.note + '</p>' +
+				  '<footer>' + note.authorName + '</footer>' +
+				'</blockquote>';
+		});
+
+		result +=
+					'</div>' +
+						'<div class="modal-footer">' +
+							'<button type="button" id="close" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
+						'</div>' +
+					'</div>' +
+				'</div>' +
+			'</div>';
+
+		return result;
+	}
 	/* ]]> */
 </script>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/submitter.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/submitter.html
@@ -78,6 +78,7 @@
 									<th th:text="#{tableheader.proposalType}">Vorschlagstyp</th>
 									<th th:text="#{tableheader.proposalStatus}">Status</th>
 									<th></th>
+									<th></th>
 								</tr>
 							</thead>
 <!-- 							<tbody> -->
@@ -279,34 +280,50 @@
 				},				
 				"aaSorting": [[ 3, "asc" ]],
 				"aoColumns": [
-					{ 
+					{
 						"mDataProp": "title",
-						"sWidth": "50%",
+						"sWidth": "45%",
 						"bSortable": true
 					},
-					{ 
+					{
 						"mDataProp": "itemClassName",
 						"sWidth": "15%",
 						"bSearchable": true,
 						"bSortable": false
 					},
-					{ 	
+					{
 						"mDataProp": "proposalType",
 						"sWidth": "15%",
 					 	"bSortable": false
 					},
-					{ 
+					{
 						"mDataProp": "proposalStatus",
 						"sWidth": "10%",
 						"bSortable": true
 					},
-					{ 
+					{
+						"sWidth": "5%",
+						"bSortable": false
+					},
+					{
 						"sWidth": "10%",
 						"bSortable": false
 					},
 				],
 				"aoColumnDefs": [
 					{ "aTargets": [4],
+					  "mData": null,
+					  "mRender": function (data, type, full) {
+						  var icons = "";
+						  if (full.hasNotes) {
+							  icons += showNotesButton(full);
+							  icons += notesPopup(full);
+						  }
+
+						  return icons;
+					  }
+					},
+					{ "aTargets": [5],
 					  "mData": null,
 					  "mRender": function (data, type, full) {
 						  var actions = "";


### PR DESCRIPTION
Adds an envelope icon to the proposal list of the submitting organization
if there are `ProposalNote` attached to a proposal, e.g. because it was
return by the Register Manager or Control Body. Clicking the icon displays
a popup showing the notes' content.