### PR TITLE
fix: don't manipulate admin user as part of the database migration

### DIFF
--- a/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V15__1.5_refactor_admin_user_to_default.sql
+++ b/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V15__1.5_refactor_admin_user_to_default.sql
@@ -1,7 +1,0 @@
--- admin@example.org change to "geodetic.register@ribose.com" , reset password "a"
--- this is to reset as Ribose required on May 24 2019
-
-UPDATE "public"."registryuser"
-SET "emailaddress" = 'geodetic.register@ribose.com',
-    "passwordhash" = '$2a$12$w8AoYGP2UxTsnrajt0UJ6eExjm1AD/IG2RD87wx5qoXkKXiCEgYT6'
-WHERE "emailaddress" = 'admin@example.org';


### PR DESCRIPTION
Changing the admin user must not be done as part of the database migration mechanism. This change is specific to the Ribose environment and does not apply to other environments. My suggestion would be to integrate that into your deployment process instead.

There will be an entry in the `schema_version` table that needs to be removed after this patch is merged, otherwise the software will not boot:

```
DELETE FROM schema_version WHERE version_rank = 15
```