### PR TITLE
Implement item class for managing Extents

### DIFF
--- a/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V15__Add_extent_item.sql
+++ b/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V15__Add_extent_item.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS extentitem (
+    uuid uuid NOT NULL,
+    dateaccepted date,
+    dateamended date,
+    definition text,
+    description text,
+    itemidentifier numeric(19,2) NOT NULL,
+    name text NOT NULL,
+    status character varying(255),
+    itemclass_uuid uuid,
+    register_uuid uuid,
+    specificationsource_uuid uuid,
+    extent_uuid uuid,
+    CONSTRAINT extentitem_pkey PRIMARY KEY (uuid),
+    CONSTRAINT fk_2qymbvgp3kssogq6xetcisru5 FOREIGN KEY (register_uuid)
+        REFERENCES re_register (uuid),
+    CONSTRAINT fk_6ha597ro4q5n8nee3o1d7qmi4 FOREIGN KEY (itemclass_uuid)
+        REFERENCES re_itemclass (uuid),
+    CONSTRAINT fk_f4l5vjmlltl6arek8bhqmlfmj FOREIGN KEY (specificationsource_uuid)
+        REFERENCES re_reference (uuid),
+    CONSTRAINT fk_fnp9hbspy6veiarnst0bbb9qq FOREIGN KEY (extent_uuid)
+        REFERENCES ex_extent (uuid)
+);
+
+CREATE TABLE IF NOT EXISTS extentitem_aud (
+    uuid uuid NOT NULL,
+    rev integer NOT NULL,
+    revtype smallint,
+    dateaccepted date,
+    dateamended date,
+    definition text,
+    description text,
+    itemidentifier numeric(19,2),
+    name text,
+    status character varying(255),
+    itemclass_uuid uuid,
+    register_uuid uuid,
+    specificationsource_uuid uuid,
+    extent_uuid uuid,
+    CONSTRAINT extentitem_aud_pkey PRIMARY KEY (uuid, rev),
+    CONSTRAINT fk_kvdko1j2dfoy0mgvbu9dmfetj FOREIGN KEY (rev)
+        REFERENCES public.revinfo (rev)
+);

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/initialization/IsoRegistryInitializer.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/initialization/IsoRegistryInitializer.java
@@ -146,6 +146,7 @@ public class IsoRegistryInitializer extends AbstractRegistryInitializer implemen
 			addItemClass("OperationParameter", r);
 			addItemClass("PrimeMeridian", r);
 			addItemClass("UnitOfMeasure", r);
+			addItemClass("Extent", r);
 		}
 		catch (Throwable t) {
 			throw new RuntimeException(t.getMessage(), t);

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/initialization/IsoRegistryInitializer.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/initialization/IsoRegistryInitializer.java
@@ -243,8 +243,7 @@ public class IsoRegistryInitializer extends AbstractRegistryInitializer implemen
 			log(String.format("> Adding item class '%s' to register '%s'...\n", name, r.getName()));
 			ic = new RE_ItemClass();
 			ic.setName(name);
-			r.getContainedItemClasses().add(ic);
-			ic.getRegisters().add(r);
+			r.addContainedItemClass(ic);
 			ic = itemClassRepository.save(ic);
 			r = registerRepository.save(r);
 		}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/RegistryFixService.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/RegistryFixService.java
@@ -1,0 +1,52 @@
+package org.iso.registry.api.registry;
+
+import javax.transaction.Transactional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import de.geoinfoffm.registry.api.RegisterService;
+import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
+import de.geoinfoffm.registry.core.model.iso19135.RE_Register;
+import de.geoinfoffm.registry.persistence.ItemClassRepository;
+import de.geoinfoffm.registry.persistence.RegisterRepository;
+
+@Transactional
+@Service
+public class RegistryFixService
+{
+	@Autowired
+	private ItemClassRepository itemClassRepository;
+
+	@Autowired
+	private RegisterRepository registerRepository;
+
+	@Autowired
+	private RegisterService registerService;
+
+	public void createExtentItemClass(StringBuilder log) {
+		log.append("Attempting to add item class 'Extent' to ISO Geodetic Register...\n");
+
+		RE_ItemClass extentItemClass = itemClassRepository.findByName("Extent");
+		if (extentItemClass == null) {
+			extentItemClass = new RE_ItemClass();
+			extentItemClass.setName("Extent");
+			extentItemClass = itemClassRepository.save(extentItemClass);
+		}
+
+		RE_Register geodeticRegister = registerRepository.findByName("ISO Geodetic Register");
+		if (geodeticRegister == null) {
+			log.append("Register \"ISO Geodetic Register\" does not exist.\n");
+			return;
+		}
+
+		if (!registerService.containsItemClass(geodeticRegister, "Extent")) {
+			geodeticRegister.addContainedItemClass(extentItemClass);
+			geodeticRegister = registerRepository.save(geodeticRegister);
+			log.append(">>> Item class 'Extent' added successfully.\n");
+		}
+		else {
+			log.append(">>> Item class 'Extent' already contained, aborting.\n");
+		}
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ExtentItemProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ExtentItemProposalDTO.java
@@ -1,0 +1,107 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.iso.registry.core.model.iso19115.extent.EX_GeographicBoundingBox;
+import org.iso.registry.core.model.iso19115.extent.ExtentItem;
+import org.isotc211.iso19135.RE_RegisterItem_Type;
+
+import de.geoinfoffm.registry.api.RegisterItemProposalDTO;
+import de.geoinfoffm.registry.api.soap.Addition_Type;
+import de.geoinfoffm.registry.core.model.Proposal;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+import de.geoinfoffm.registry.core.model.iso19135.RE_SubmittingOrganization;
+
+public class ExtentItemProposalDTO extends RegisterItemProposalDTO
+{
+	private String description;
+	private List<EX_GeographicBoundingBox> geographicBoundingBoxes;
+
+	public ExtentItemProposalDTO() {
+		super("Extent");
+	}
+
+	// TODO Activate after extending isogcp-registry.xsd
+//	public ExtentItemProposalDTO(ExtentItemProposal_Type itemDetails) {
+//		super(itemDetails);
+//	}
+
+	public ExtentItemProposalDTO(Addition_Type proposal, RE_SubmittingOrganization sponsor) {
+		super(proposal, sponsor);
+	}
+
+	public ExtentItemProposalDTO(ExtentItem item) {
+		super(item);
+	}
+
+	public ExtentItemProposalDTO(Proposal proposal) {
+		super(proposal);
+	}
+
+	public ExtentItemProposalDTO(RE_RegisterItem_Type item, RE_SubmittingOrganization sponsor) {
+		super(item, sponsor);
+	}
+
+	public ExtentItemProposalDTO(String itemClassName) {
+		super(itemClassName);
+	}
+
+	@Override
+	public void setAdditionalValues(RE_RegisterItem registerItem, EntityManager entityManager) {
+		super.setAdditionalValues(registerItem, entityManager);
+
+		if (registerItem instanceof ExtentItem) {
+			ExtentItem item = (ExtentItem)registerItem;
+
+			ExtentDTO dto = new ExtentDTO();
+			dto.setDescription(this.description);
+			for (EX_GeographicBoundingBox box : this.getGeographicBoundingBoxes()) {
+				dto.getGeographicBoundingBoxes().add(box);
+			}
+
+			if (item.getExtent() == null) {
+				item.setExtent(dto.getNewExtent());
+			}
+			else {
+				dto.copyValues(item.getExtent());
+			}
+		}
+	}
+
+	@Override
+	public void loadAdditionalValues(RE_RegisterItem registerItem) {
+		super.loadAdditionalValues(registerItem);
+
+		if (registerItem instanceof ExtentItem) {
+			ExtentItem item = (ExtentItem)registerItem;
+
+			this.description = item.getExtent().getDescription();
+
+			ExtentDTO dto = new ExtentDTO(item.getExtent());
+			this.getGeographicBoundingBoxes().addAll(dto.getGeographicBoundingBoxes());
+		}
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public List<EX_GeographicBoundingBox> getGeographicBoundingBoxes() {
+		if (geographicBoundingBoxes == null) {
+			geographicBoundingBoxes = new ArrayList<>();
+		}
+		return geographicBoundingBoxes;
+	}
+
+	public void setGeographicBoundingBoxes(List<EX_GeographicBoundingBox> geographicBoundingBoxes) {
+		this.geographicBoundingBoxes = geographicBoundingBoxes;
+	}
+
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ExtentItemViewBean.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ExtentItemViewBean.java
@@ -1,0 +1,102 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.iso.registry.core.model.iso19115.extent.EX_GeographicBoundingBox;
+import org.iso.registry.core.model.iso19115.extent.ExtentItem;
+import org.isotc211.iso19135.RE_RegisterItem_Type;
+
+import de.geoinfoffm.registry.api.RegisterItemViewBean;
+import de.geoinfoffm.registry.core.model.Appeal;
+import de.geoinfoffm.registry.core.model.Proposal;
+import de.geoinfoffm.registry.core.model.SimpleProposal;
+import de.geoinfoffm.registry.core.model.Supersession;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+
+public class ExtentItemViewBean extends RegisterItemViewBean
+{
+	private String description;
+	private List<EX_GeographicBoundingBox> geographicBoundingBoxes;
+
+	public ExtentItemViewBean(RE_RegisterItem item) {
+		super(item);
+	}
+
+	public ExtentItemViewBean(RE_RegisterItem item, boolean loadDetails) {
+		super(item, loadDetails);
+	}
+
+	public ExtentItemViewBean(Proposal proposal) {
+		super(proposal);
+	}
+
+	public ExtentItemViewBean(SimpleProposal proposal) {
+		super(proposal);
+	}
+
+	public ExtentItemViewBean(Appeal appeal) {
+		super(appeal);
+	}
+
+	public ExtentItemViewBean(Supersession supersession) {
+		super(supersession);
+	}
+
+	@Override
+	public void setXmlValues(RE_RegisterItem_Type result) {
+		super.setXmlValues(result);
+		// TODO Implement after extending isogcp-registry.xsd
+//		if (result instanceof ExtentItem_Type) {
+//			final UnitOfMeasureItem_Type xmlBean = (UnitOfMeasureItem_Type)result;
+//			final UnitOfMeasureItemViewBean viewBean = this;
+//			if (viewBean.getStandardUnit() != null && viewBean.getStandardUnit().getUuid() != null) {
+//				final UnitOfMeasureItem_PropertyType xmlBeanProp = new UnitOfMeasureItem_PropertyType();
+//				xmlBeanProp.setUuidref(viewBean.getStandardUnit().getUuid().toString());
+//				xmlBean.setStandardUnit(xmlBeanProp);
+//			}
+//
+//			xmlBean.setMeasureType(RegistryModelXmlConverter.convertModelToXmlMeasureType(viewBean.getMeasureType()));
+//			xmlBean.setSymbol(GcoConverter.convertToGcoString(viewBean.getSymbol()));
+//			xmlBean.setOffsetToStandardUnit(IsoXmlFactory.real(viewBean.getOffsetToStandardUnit()));
+//			xmlBean.setScaleToStandardUnitDenominator(IsoXmlFactory.real(viewBean.getScaleToStandardUnitDenominator()));
+//			xmlBean.setScaleToStandardUnitNumerator(IsoXmlFactory.real(viewBean.getScaleToStandardUnitNumerator()));
+//			xmlBean.setSymbol(IsoXmlFactory.characterString(viewBean.getSymbol()));
+//		}
+	}
+
+	@Override
+	protected void addAdditionalProperties(RE_RegisterItem registerItem, boolean loadDetails) {
+		super.addAdditionalProperties(registerItem, loadDetails);
+
+		if (!(registerItem instanceof ExtentItem)) {
+			return;
+		}
+
+		ExtentItem item = (ExtentItem)registerItem;
+
+		ExtentDTO dto = new ExtentDTO(item.getExtent());
+		this.description = dto.getDescription();
+		this.getGeographicBoundingBoxes().addAll(dto.getGeographicBoundingBoxes());
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public List<EX_GeographicBoundingBox> getGeographicBoundingBoxes() {
+		if (geographicBoundingBoxes == null) {
+			geographicBoundingBoxes = new ArrayList<>();
+		}
+		return geographicBoundingBoxes;
+	}
+
+	public void setGeographicBoundingBoxes(List<EX_GeographicBoundingBox> geographicBoundingBoxes) {
+		this.geographicBoundingBoxes = geographicBoundingBoxes;
+	}
+
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/iso19115/extent/ExtentItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/iso19115/extent/ExtentItem.java
@@ -1,0 +1,46 @@
+package org.iso.registry.core.model.iso19115.extent;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+
+import de.geoinfoffm.registry.core.ItemClass;
+import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
+import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
+import de.geoinfoffm.registry.core.model.iso19135.RE_Register;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+
+@Access(AccessType.FIELD)
+@ItemClass("Extent")
+@Audited @Entity
+public class ExtentItem extends RE_RegisterItem
+{
+	@ManyToOne(cascade = CascadeType.ALL)
+	private EX_Extent extent;
+
+	protected ExtentItem() {
+		super();
+	}
+
+	public ExtentItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
+			RE_AdditionInformation additionInformation) {
+
+		super(register, itemClass, name, definition, additionInformation);
+	}
+
+	public ExtentItem(EX_Extent extent) {
+		this.extent = extent;
+	}
+
+	public EX_Extent getExtent() {
+		return this.extent;
+	}
+
+	public void setExtent(EX_Extent extent) {
+		this.extent = extent;
+	}
+}

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/AdministrationController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/AdministrationController.java
@@ -146,6 +146,11 @@ public class AdministrationController
 //		binder.setValidator(new AdministrationValidator(userService, organizationService));
 	}
 	
+	@RequestMapping(value = "/fixes", method = RequestMethod.GET)
+	public String showRegistryFixes() {
+		return "admin/fixes";
+	}
+
 	/**
 	 * Fetches all {@link RegistryUser}s from the repository and puts them
 	 * in the view model.

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/FixController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/FixController.java
@@ -1,0 +1,188 @@
+/**
+ * Copyright (c) 2017, German Federal Agency for Cartography and Geodesy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *     * Redistributions of source code must retain the above copyright
+ *     	 notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *     	 copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ *     * The names "German Federal Agency for Cartography and Geodesy",
+ *       "Bundesamt für Kartographie und Geodäsie", "BKG", "GDI-DE",
+ *       "GDI-DE Registry" and the names of other contributors must not
+ *       be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE GERMAN
+ * FEDERAL AGENCY FOR CARTOGRAPHY AND GEODESY BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * =====================================================================
+ *
+ * Integration into the ISO Geodetic Registry was developed by
+ * Natural Resources Canada.
+ *
+ * TODO Add license
+ *
+ * Copyright (c) 2020, Natural Resources Canada
+ */
+package org.iso.registry.client.controller;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.iso.registry.api.registry.RegistryFixService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import de.geoinfoffm.registry.api.UserRegistrationException;
+import de.geoinfoffm.registry.client.web.AbstractController;
+import de.geoinfoffm.registry.core.ItemClassRegistry;
+import de.geoinfoffm.registry.core.UnauthorizedException;
+import de.geoinfoffm.registry.core.configuration.RegistryConfiguration;
+import de.geoinfoffm.registry.core.model.iso19135.InvalidProposalException;
+import de.geoinfoffm.registry.persistence.ItemClassRepository;
+
+/**
+ * Controller class for methods fixing registry content
+ *
+ * @author Florian Esser
+ *
+ */
+@Controller
+@Secured("ROLE_ADMIN")
+@RequestMapping("/fix")
+public class FixController extends AbstractController
+{
+	@Autowired
+	private RegistryConfiguration registryConfiguration;
+
+	@Autowired
+	private RegistryFixService fixer;
+
+	private static boolean isFixing = false;
+
+	private StringBuilder initLog;
+
+	/**
+	 * Create the controller
+	 */
+	@Autowired
+	public FixController(ItemClassRepository itemClassRepository, ItemClassRegistry itemClassRegistry) {
+		super();
+	}
+
+	/**
+	 * Retrieve the status of the current fix operation
+	 *
+	 * @param request The underlying request
+	 * @return <code>204 (No content)</code> if no fixing operation is ongoing,
+	 *         <code>206 (Partial content)</code> if the current fixing is still ongoing,
+	 *         or <code>200 (OK)</code> if the fix operation is finished.
+	 * @throws UnauthorizedException
+	 */
+	@RequestMapping(value = "/{fix}/status", method = RequestMethod.GET)
+	public ResponseEntity<String> fixStatus(HttpServletRequest request) throws UnauthorizedException {
+		if (initLog == null) {
+			return new ResponseEntity<String>("Not currently fixing.", HttpStatus.NO_CONTENT);
+		}
+		else if (isFixing) {
+			return new ResponseEntity<String>(initLog.toString(), HttpStatus.PARTIAL_CONTENT);
+		}
+		else {
+			return new ResponseEntity<String>(initLog.toString(), HttpStatus.OK);
+		}
+	}
+
+	/**
+	 * Show the fix form
+	 *
+	 * @param request The underlying request
+	 * @param fix     The fix to apply
+	 * @param model   The model
+	 * @return The name of the view to display next
+	 * @throws InvalidProposalException
+	 * @throws UserRegistrationException
+	 * @throws UnauthorizedException
+	 */
+	@RequestMapping(value = "/{fix}", method = RequestMethod.GET)
+	public String fix(HttpServletRequest request, @PathVariable("fix") String fix, Model model)
+			throws InvalidProposalException, UserRegistrationException, UnauthorizedException {
+		model.addAttribute("fix", fix);
+
+		return "fix";
+	}
+
+	/**
+	 * Start a fix operation
+	 *
+	 * @param request The underlying request
+	 * @param fix     The fix to apply
+	 * @return The status message
+	 * @throws Exception
+	 */
+	@Async
+	@Transactional
+	@RequestMapping(value = "/{fix}/start", method = RequestMethod.GET)
+	public ResponseEntity<String> fixStart(HttpServletRequest request, @PathVariable("fix") String fix) throws Exception {
+		if (StringUtils.isEmpty(fix)) {
+			return new ResponseEntity<String>("Missing 'fix'", HttpStatus.BAD_REQUEST);
+		}
+
+		HttpStatus status = HttpStatus.OK;
+		String message = "";
+		try {
+			if (!isFixing) {
+				isFixing = true;
+				initLog = new StringBuilder();
+
+				boolean mailEnabled = registryConfiguration.isMailEnabled();
+				registryConfiguration.setMailEnabled(false);
+
+				switch (fix) {
+					case "create-extent-item-class":
+						fixer.createExtentItemClass(initLog);
+						break;
+					default:
+						message = String.format("Unknown fix: '%s'", fix);
+						initLog.append(message);
+						status = HttpStatus.NOT_FOUND;
+				}
+
+				initLog.append("\nFinished.");
+				isFixing = false;
+
+				registryConfiguration.setMailEnabled(mailEnabled);
+			}
+		}
+		finally {
+			isFixing = false;
+		}
+
+		return new ResponseEntity<String>(message, status);
+	}
+}

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/RegisterController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/RegisterController.java
@@ -316,6 +316,7 @@ public class RegisterController extends AbstractController
 				addItemClassToList("OperationParameter", itemClasses);
 				addItemClassToList("PrimeMeridian", itemClasses);
 				addItemClassToList("UnitOfMeasure", itemClasses);
+				addItemClassToList("Extent", itemClasses);
 			}
 			else {
 				addItemClassToList(itemClassParam, itemClasses);

--- a/src/iso-registry-client/src/main/resources/i18n/messages.xml
+++ b/src/iso-registry-client/src/main/resources/i18n/messages.xml
@@ -27,6 +27,8 @@
 	<entry key="navbar.login.button.register">Register</entry>
 	<entry key="navbar.help">Documentation</entry>	
 	<entry key="navbar.help.userguide">User Guide</entry>
+	<entry key="navbar.administration">Additional Administration</entry>
+	<entry key="navbar.fixes">Fixes</entry>
 
 	<entry key="mgmt.submitter.content.header">Submitting organization: List of proposals</entry>
 	<entry key="mgmt.manager.content.header">Register manager: List of pending proposals</entry>
@@ -41,6 +43,7 @@
 	<entry key="admin.organization.main.header">Master data</entry>
 	<entry key="admin.organization.roles.header">Roles</entry>
 	<entry key="admin.organization.users.header">Users</entry>
+	<entry key="admin.fixes.content.header">Registry Fixes</entry>
 	<entry key="proposal.discussion.content.header">Discuss proposal</entry>
 	
 	<entry key="tableheader.name">Name</entry>
@@ -84,6 +87,7 @@
 	<entry key="tableheader.axisDirection">Axis direction</entry>
 	<entry key="tableheader.citation">Citation</entry>
 	<entry key="tableheader.scope">Scope</entry>
+	<entry key="tableheader.ticket">Related issue</entry>
 
 	<entry key="header.supersededItems">Superseded items</entry>	
 	<entry key="header.supersedingItems">Successors</entry>
@@ -223,6 +227,7 @@
 	<entry key="button.gml">Show GML</entry>
 	<entry key="button.uploadProposals">Upload proposals</entry>
 	<entry key="button.downloadExcel">Excel export</entry>
+	<entry key="button.applyFix">Apply fix</entry>
 
 	<entry key="NOT_VALID">not valid</entry>
 	<entry key="VALID">valid</entry>

--- a/src/iso-registry-client/src/main/resources/i18n/messages.xml
+++ b/src/iso-registry-client/src/main/resources/i18n/messages.xml
@@ -424,10 +424,10 @@
 	<entry key="form.label.isoA2Code">ISO Alpha-2 Code</entry>
 	<entry key="form.label.isoA3Code">ISO Alpha-3 Code</entry>
 	<entry key="form.label.isoNCode">ISO num. Code</entry>
-	<entry key="form.label.northernLatitude">Northern Lat</entry>
-	<entry key="form.label.southernLatitude">Southern Lat</entry>
-	<entry key="form.label.easternLongitude">Eastern Lon</entry>
-	<entry key="form.label.westernLongitude">Western Lon</entry>
+	<entry key="form.label.northernLatitude">North-bound Lat</entry>
+	<entry key="form.label.southernLatitude">South-bound Lat</entry>
+	<entry key="form.label.easternLongitude">East-bound Lon</entry>
+	<entry key="form.label.westernLongitude">West-bound Lon</entry>
 	<entry key="form.label.remarks">Remarks</entry>
 	<entry key="form.label.anchorDefinition">Anchor Definition</entry>
 	<entry key="form.label.informationSource">Information Source</entry>

--- a/src/iso-registry-client/src/main/resources/itemclasses/org.iso.registry.core.model.iso19115.extent.ExtentItem.xml
+++ b/src/iso-registry-client/src/main/resources/itemclasses/org.iso.registry.core.model.iso19115.extent.ExtentItem.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<reg:ItemClassConfiguration xmlns:reg="http://www.geoinfoffm.de/registry" itemClassName="Extent">
+	<dtoClass>org.iso.registry.api.registry.registers.gcp.ExtentItemProposalDTO</dtoClass>
+	<viewBeanClass>org.iso.registry.api.registry.registers.gcp.ExtentItemViewBean</viewBeanClass>
+	<viewItemTemplate>registry/registers/gcp/extent_view_item</viewItemTemplate>
+	<xmlType>org.iso.registry.api.ExtentItem_Type</xmlType>
+	<viewProposalTemplate>registry/registers/gcp/extent_edit_addition</viewProposalTemplate>
+	<createProposalTemplate>registry/registers/gcp/extent_create_addition</createProposalTemplate>
+	<editProposalTemplate>registry/registers/gcp/extent_edit_addition</editProposalTemplate>
+</reg:ItemClassConfiguration>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/admin/fixes.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/admin/fixes.html
@@ -1,0 +1,98 @@
+<!--
+/**
+ * Copyright (c) 2017, German Federal Agency for Cartography and Geodesy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *     * Redistributions of source code must retain the above copyright
+ *     	 notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *     	 copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ *     * The names "German Federal Agency for Cartography and Geodesy",
+ *       "Bundesamt für Kartographie und Geodäsie", "BKG", "GDI-DE",
+ *       "GDI-DE Registry" and the names of other contributors must not
+ *       be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE GERMAN
+ * FEDERAL AGENCY FOR CARTOGRAPHY AND GEODESY BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * =====================================================================
+ *
+ * Integration into the ISO Geodetic Registry was developed by
+ * Natural Resources Canada.
+ *
+ * TODO Add license
+ *
+ * Copyright (c) 2020, Natural Resources Canada
+ */
+
+/**
+  * View that shows available registry fixes and allows an administrator to apply them.
+  *
+  * All fragments expect ${basePath} to exist in the model and contain the
+  * static part of the URL path.
+  *
+  * @author Florian Esser
+  *
+  */
+-->
+<!DOCTYPE html>
+<html>
+<head th:include="layout :: headerFragment">
+</head>
+<body>
+	<div th:include="layout :: navbarFragment"></div>
+
+	<div class="container-fluid" sec:authorize="@registrySecurity.hasRole('ROLE_ADMIN')">
+		<div class="row-fluid">
+			<div class="col-md-3">
+				<div th:include="layout :: navtree"></div>
+			</div>
+			<div class="col-md-9" role="main">
+				<div class="panel panel-default">
+					<div class="panel-heading">
+						<h3 class="panel-title" th:text="#{admin.fixes.content.header}"></h3>
+					</div>
+					<div style="padding: 10px">
+						<table id="fixesTable" class="datatable table table-striped">
+							<thead>
+								<tr>
+									<th th:text="#{tableheader.ticket}"/>
+									<th th:text="#{tableheader.name}"/>
+									<th/>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td><a href="https://github.com/ISO-TC211/iso-geodetic-registry/issues/49">#49 (iso-geodetic-registry)</a></td>
+									<td>Add Extent item class</td>
+									<td><a class="btn btn-default" th:href="@{__${basePath}__/fix/create-extent-item-class}" th:text="#{button.applyFix}" /></td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div th:replace="layout :: footer"></div>
+</body>
+</html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/fix.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/fix.html
@@ -1,0 +1,129 @@
+<!--
+/**
+ * Copyright (c) 2017, German Federal Agency for Cartography and Geodesy
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *     * Redistributions of source code must retain the above copyright
+ *     	 notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above
+ *     	 copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ *     * The names "German Federal Agency for Cartography and Geodesy",
+ *       "Bundesamt für Kartographie und Geodäsie", "BKG", "GDI-DE",
+ *       "GDI-DE Registry" and the names of other contributors must not
+ *       be used to endorse or promote products derived from this
+ *       software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE GERMAN
+ * FEDERAL AGENCY FOR CARTOGRAPHY AND GEODESY BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * =====================================================================
+ *
+ * Integration into the ISO Geodetic Registry was developed by
+ * Natural Resources Canada.
+ *
+ * TODO Add license
+ *
+ * Copyright (c) 2020, Natural Resources Canada
+ */
+
+/**
+  * View that shows the progress of a fix
+  *
+  * All fragments expect ${basePath} to exist in the model and contain the
+  * static part of the URL path.
+  *
+  * @author Florian Esser
+  *
+  */
+-->
+<!DOCTYPE html>
+<html>
+	<head th:include="layout :: headerFragment"/>
+	<body>
+	<div th:include="layout :: navbarFragment"></div>
+
+	<div class="container-fluid">
+		<div class="row-fluid">
+			<div class="col-md-3">
+				<div th:include="layout :: navtree"></div>
+			</div>
+			<div class="col-md-9" role="main">
+				<div class="row">
+					<pre id="fix-log"></pre>
+					<span id="spinner" class="fa fa-spinner"></span>
+					<button id="back" class="btn btn-default disabled" th:text="#{button.back}" onclick="history.back();">Zurück</button>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<div th:replace="layout :: footer"></div>
+
+</body>
+
+<script type="text/javascript" th:inline="text">
+	$(document).ready(function() {
+
+		var timer, delay = 5000;
+
+		var basePath = '[[${basePath}]]';
+		if (basePath !== '') {
+			basePath = basePath.replace('~', '');
+		}
+		basePath = basePath + '/fix/';
+
+		$.ajax({
+		      type    : 'GET',
+		      url     : basePath + '[[${fix}]]/start',
+		      success : function(data) {
+		                }
+		});
+
+		timer = setInterval(function() {
+			$.ajax({
+				type    	 : 'GET',
+				url     	 : basePath + '[[${fix}]]/status',
+				statusCode : {
+					206: function(data) {
+						$('#fix-log').text(data);
+						$('#spinner').addClass('fa-spinner');
+
+						var n = $(document).height();
+						$('html, body').animate({ scrollTop: n }, 50);
+					},
+					200: function(data) {
+						$('#fix-log').text(data);
+						$('#spinner').removeClass('fa-spinner');
+						$('#back').removeClass('disabled');
+
+						var n = $(document).height();
+						$('html, body').animate({ scrollTop: n }, 50);
+						clearInterval(timer);
+					},
+					204: function(data) {
+						$('#fix-log').text('Not currently fixing.');
+						clearInterval(timer);
+					},
+				}
+			});
+		}, delay);
+	});
+</script>
+</html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/layout.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/layout.html
@@ -432,6 +432,11 @@
                                                th:text="#{navbar.userManagement.organizations}">Organisationen</a></li>
               </ul>
             </li>
+			<li id="nav_administration" sec:authorize="hasRole('ROLE_ADMIN')"><a href="#" th:text="#{navbar.administration}"></a>
+				<ul>
+					<li id="adminfixes" sec:authorize="hasRole('ROLE_ADMIN')"><a th:href="@{__${basePath}__/admin/fixes}" th:text="#{navbar.fixes}"></a></li>
+				</ul>
+			</li>
             <!-- 							<li id="adminproposals" sec:authorize="hasRole('ROLE_ADMIN')"><a th:href="@{__${basePath}__/admin/proposals}" th:text="#{navbar.proposalManagement}">Vorschlagsverwaltung</a></li> -->
           </ul>
         </div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/create_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/create_item.html
@@ -36,7 +36,7 @@
 							<div th:if="${showExtentPanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/extent_panel :: extentDetailsPanel"/>
 							</div>
-							<div th:unless="${proposal.isClarification()}">
+							<div th:if="${showInformationSourcePanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/infosrc_panel :: informationSourceDetailsPanel"/>
 							</div>
 							<div th:replace="globals :: proposalDetailsPanel (isCollapsible='true')"/>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/edit_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/edit_item.html
@@ -36,7 +36,7 @@
 							<div th:if="${showExtentPanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/extent_panel :: extentDetailsPanel"/>
 							</div>
-							<div th:unless="${proposal.isClarification()}">
+							<div th:if="${showInformationSourcePanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/infosrc_panel :: informationSourceDetailsPanel"/>
 							</div>
 							<div th:replace="globals :: proposalDetailsPanel (isCollapsible='true')"/>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/axis_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/axis_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ccrs_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.compoundCrs}, 'registry/registers/gcp/ccrs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/concatop_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.concatenatedOperation}, 'registry/registers/gcp/concatop_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/crs_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.crs}, 'registry/registers/gcp/crs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/cs_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.cs}, 'registry/registers/gcp/cs_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/datum_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.datum}, 'registry/registers/gcp/datum_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/ellipsoid_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.ellipsoid}, 'registry/registers/gcp/ellipsoid_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
+<body th:include="registry/registers/create_item :: body(#{header.extent}, 'registry/registers/gcp/extent_details')"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_details.html
@@ -1,0 +1,187 @@
+<div th:fragment="details">
+	<div class="row">
+		<div class="col-md-12">
+			<div th:with="property='name',rows=2,cols=60,label=#{form.label.name},placeholder=#{form.placeholder.name},help=#{form.help.name},isRequired='true'">
+				<div th:replace="globals :: textField(${property}, ${inputType}, ${label}, ${placeholder}, ${isRequired})"/>
+			</div>
+
+			<div class="row">
+				<div th:unless="${isClarification}" class="col-md-12" th:with="property='description',modifier='extent',inputType='text',label=#{form.label.description},placeholder=#{form.placeholder.description},isRequired='true'">
+					<div th:replace="globals :: textArea"/>
+				</div>
+				<div th:if="${isClarification}" class="col-md-12" th:with="property='description',modifier='extent',inputType='text',label=#{form.label.description},placeholder=#{form.placeholder.description},isRequired='false',isReadOnly='true'">
+					<div th:replace="globals :: textArea"/>
+				</div>
+			</div>
+
+			<ul class="nav nav-tabs">
+						<li class="active"><a href="#geographicExtent" data-toggle="tab" th:text="#{tabs.geographicExtent}"></a></li>
+		<!-- Vertical and Temporal Extents are not supported in the ISO Geodetic Registry -->
+		<!-- 				<li class="disabled"><a href="#verticalExtent" data-toggle="tab" th:text="#{tabs.verticalExtent}"></a></li> -->
+		<!-- 				<li class="disabled"><a href="#temporalExtent" data-toggle="tab" th:text="#{tabs.temporalExtent}"></a></li> -->
+			</ul>
+
+			<div class="tab-content">
+				<div id="geographicExtent" class="tab-pane in active" style="padding-top: 10px">
+					<div class="row">
+						<div class="col-md-12">
+							<table id="bboxTable" class="datatable table table-striped" th:with="isEditable=(${isProposal} and !${proposal.isClarification()} and !${isReadOnly})">
+								<thead>
+									<tr>
+										<th th:text="#{form.label.northernLatitude}"/>
+										<th th:text="#{form.label.easternLongitude}"/>
+										<th th:text="#{form.label.southernLatitude}"/>
+										<th th:text="#{form.label.westernLongitude}"/>
+										<th>
+											<a th:unless="!${isProposal} or ${isReadOnly} or ${proposal.isClarification()}" href="#dialog-boundingbox" id="addBoundingBox" data-toggle="modal" class="btn btn-default btn-sm" th:text="#{button.addBoundingBox}"/>
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr th:each="row,rowStat : *{geographicBoundingBoxes}" th:id="'row-' + ${rowStat.index}">
+										<td>
+											<input th:field="*{geographicBoundingBoxes[__${rowStat.index}__].northBoundLatitude}" th:disabled="!${isEditable}"/>
+										</td>
+										<td>
+											<input th:field="*{geographicBoundingBoxes[__${rowStat.index}__].eastBoundLongitude}" th:disabled="!${isEditable}"/>
+										</td>
+										<td>
+											<input th:field="*{geographicBoundingBoxes[__${rowStat.index}__].southBoundLatitude}" th:disabled="!${isEditable}"/>
+										</td>
+										<td>
+											<input th:field="*{geographicBoundingBoxes[__${rowStat.index}__].westBoundLongitude}" th:disabled="!${isEditable}"/>
+										</td>
+										<td>
+											<button type="button" th:if="${isEditable}" th:text="#{button.removeRow}" class="btn btn-sm btn-default btn-deleterow" name="removeRow" th:attr="data-index=${rowStat.index}" th:value="${rowStat.index}">Remove row</button>
+										</td>
+									</tr>
+								</tbody>
+							</table>
+						</div>
+					</div>
+					<div class="row">
+		<!-- Bounding polygon and Geographic Description are not supported in the ISO Geodetic Registry -->
+		<!-- 						<a th:unless="!${isProposal} or ${proposal.isClarification()}" href="#dialog-boundingpolygon" id="addBoundingPolygon" data-toggle="modal" class="btn btn-default btn-sm disabled" th:text="#{button.addBoundingPolygon}"/> -->
+		<!-- 						<a th:unless="!${isProposal} or ${proposal.isClarification()}" href="#dialog-geographicdescription" id="addGeographicDescription" data-toggle="modal" class="btn btn-default btn-sm disabled" th:text="#{button.addGeographicDescription}"/> -->
+					</div>
+
+					<div class="modal fade" id="dialog-boundingbox" role="dialog">
+						<div class="modal-dialog">
+							<div class="modal-content">
+								<div class="modal-header">
+									<h4 th:text="#{popup.extent.header}">Extent</h4>
+								</div>
+								<div class="modal-body">
+									<div class="row">
+										<div class="col-md-3"/>
+										<div class="col-md-6">
+											<label class="control-label" th:for="northBoundLatitude" th:text="#{form.label.northernLatitude}"></label>
+											<input type="number" class="form-control" id="northBoundLatitude" name="northBoundLatitude"/>
+										</div>
+									</div>
+
+									<div class="row">
+										<div class="col-md-5">
+											<label class="control-label" th:for="westBoundLongitude" th:text="#{form.label.westernLongitude}"></label>
+											<input type="number" class="form-control" id="westBoundLongitude" name="westBoundLongitude"/>
+										</div>
+										<div class="col-md-1"/>
+										<div class="col-md-5">
+											<label class="control-label" th:for="eastBoundLongitude" th:text="#{form.label.easternLongitude}"></label>
+											<input type="number" class="form-control" id="eastBoundLongitude" name="eastBoundLongitude"/>
+										</div>
+									</div>
+
+									<div class="row">
+										<div class="col-md-3"/>
+										<div class="col-md-6">
+											<label class="control-label" th:for="southBoundLatitude" th:text="#{form.label.southernLatitude}"></label>
+											<input type="number" class="form-control" id="southBoundLatitude" name="southBoundLatitude"/>
+										</div>
+									</div>
+								</div>
+								<div class="modal-footer">
+									<button type="button" id="extentPopup_cancel" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Cancel</button>
+									<button type="button" id="extentPopup_ok" class="btn btn-primary" data-dismiss="modal" th:text="#{button.ok}">Ok</button>
+								</div>
+							</div>
+						</div>
+					</div>
+
+				</div>
+			</div>
+
+			<script type="text/javascript" th:inline="text">
+				/* <![CDATA[ */
+					$(document).ready(function() {
+						bboxtable = $('#bboxTable').dataTable({
+							"bPaginate": false,
+							"bFilter": false,
+							"oLanguage": {
+								  "sEmptyTable": "[[#{datatable.sEmptyTable}]]",
+								  "sInfo": "[[#{datatable.sInfo}]]",
+								  "sInfoEmpty": "[[#{datatable.sInfoEmpty}]]",
+								  "sInfoFiltered": "[[#{datatable.sInfoFiltered}]]",
+								  "sLengthMenu": "[[#{datatable.sLengthMenu}]]",
+								  "sLoadingRecords": "[[#{datatable.sLoadingRecords}]]",
+								  "sProcessing": "[[#{datatable.sProcessing}]]",
+								  "sZeroRecords": "[[#{datatable.sZeroRecords}]]",
+								  "oPaginate": {
+								        "sFirst":    "[[#{datatable.oPaginate.sFirst}]]",
+								        "sLast":     "[[#{datatable.oPaginate.sLast}]]",
+								        "sNext":     "[[#{datatable.oPaginate.sNext}]]",
+								        "sPrevious": "[[#{datatable.oPaginate.sPrevious}]]"
+								    }
+								},
+							"aaSorting": [[ 0, "asc" ]],
+							aoColumns: [
+								{
+									"bSortable" : false,
+									"sWidth" : "20%"
+								},
+								{
+									"bSortable" : false,
+									"sWidth" : "20%"
+								},
+								{
+									"bSortable" : false,
+									"sWidth" : "20%"
+								},
+								{
+									"bSortable" : false,
+									"sWidth" : "20%"
+								},
+								{
+									"bSortable" : false,
+									"sWidth" : "20%"
+								}
+							]
+					});
+
+					var extentCount = bboxtable.fnGetData().length;
+
+					$('#extentPopup_ok').click(function(e) {
+						bboxtable = $('#bboxTable').dataTable();
+						var addedRow = bboxtable.fnAddData([
+						    "<input type='number' name='geographicBoundingBoxes[" + extentCount + "].northBoundLatitude' value='" + $('#northBoundLatitude').val() + "'/>",
+						    "<input type='number' name='geographicBoundingBoxes[" + extentCount + "].eastBoundLongitude' value='" + $('#eastBoundLongitude').val() + "'/>",
+						    "<input type='number' name='geographicBoundingBoxes[" + extentCount + "].southBoundLatitude' value='" + $('#southBoundLatitude').val() + "'/>",
+						    "<input type='number' name='geographicBoundingBoxes[" + extentCount + "].westBoundLongitude' value='" + $('#westBoundLongitude').val() + "'/>",
+							"<button type='button' class='btn btn-sm btn-default btn-deleterow' name='removeRow' data-index='" + extentCount + "' value='" + extentCount + "'>Remove row</button>"
+						]);
+						var addedNode = bboxtable.fnSettings().aoData[addedRow[0]].nTr;
+						addedNode.setAttribute('id', 'row-' + extentCount++);
+					});
+
+					$(document).on('click', '.btn-deleterow', function(e) {
+						var row = $(this).closest('tr').get(0);
+						table = $('#bboxTable').dataTable();
+						table.fnDeleteRow(table.fnGetPosition(row));
+					});
+				});
+			/* ]]> */
+			</script>
+
+		</div>
+	</div>
+</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
+<body th:include="registry/registers/edit_item :: body(#{header.extent}, 'registry/registers/gcp/extent_details')"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/extent_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
+<body th:include="registry/registers/view_item :: body(#{header.extent}, 'registry/registers/gcp/extent_details')"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/method_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.operationMethod}, 'registry/registers/gcp/method_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/namsys_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.namingSystem}, 'registry/registers/gcp/namsys_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/param_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.operationParameter}, 'registry/registers/gcp/param_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.primeMeridian}, 'registry/registers/gcp/pm_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.primeMeridian}, 'registry/registers/gcp/pm_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.primeMeridian}, 'registry/registers/gcp/pm_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.primeMeridian}, 'registry/registers/gcp/pm_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/pm_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/pm_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.coordinateAxis}, 'registry/registers/gcp/pm_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_create_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/create_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')"/>
+<body th:include="registry/registers/create_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_edit_addition.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/edit_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')"/>
+<body th:include="registry/registers/edit_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/uom_view_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/uom_view_item.html
@@ -2,5 +2,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head th:include="layout :: headerFragment" />
-<body th:include="registry/registers/view_item :: body(#{header.uom}, 'registry/registers/gcp/uom_details')"/>
+<body th:include="registry/registers/view_item :: body(#{header.uom}, 'registry/registers/gcp/uom_details')" th:with="showInformationSourcePanel='true'"/>
 </html>


### PR DESCRIPTION
**WIP:** needs submodule update after https://github.com/ISO-TC211/registry-base/pull/9 is merged.

Adds the new item class "Extent" to the registry that allows managing extents as register items. Also adds the necessary GUI components to create extent items.

This is the first step towards managaing geographic extents globally as items as opposed to being managed as parts of several other item classes.

Additionally, a framework is added for applying data fixes that cannot be handled as part of the database migration framework, e.g. updating references between items or adding item classes to an existing register. A fix for the API to add item classes to registers is also contained.

#49