### PR TITLE
Migrate Conversion and Transformation to ObjectUsage interface

### DIFF
--- a/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V16__Add_domains_to_CoordinateOperationItem.sql
+++ b/src/iso-registry-api/src/main/java/de/geoinfoffm/registry/persistence/migration/V16__Add_domains_to_CoordinateOperationItem.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS coordinateoperationitem_domains (
+    coordinateoperationitem_uuid uuid NOT NULL,
+    domainofvalidity_uuid uuid,
+    scope text,
+    CONSTRAINT fk_9ggbxh4vgnuu8sg8c7rqohss5 FOREIGN KEY (domainofvalidity_uuid)
+        REFERENCES extentitem (uuid)
+);
+
+CREATE TABLE IF NOT EXISTS coordinateoperationitem_domains_aud
+(
+    rev integer NOT NULL,
+    revtype smallint NOT NULL,
+    coordinateoperationitem_uuid uuid NOT NULL,
+    setordinal integer NOT NULL,
+    domainofvalidity_uuid uuid,
+    scope text,
+    CONSTRAINT coordinateoperationitem_domains_aud_pkey PRIMARY KEY (rev, revtype, coordinateoperationitem_uuid, setordinal),
+    CONSTRAINT fk_63nh15x95747o1tc82nf985tc FOREIGN KEY (rev)
+        REFERENCES revinfo (rev)
+);

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/IdentifiedItemWithObjectUsageProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/IdentifiedItemWithObjectUsageProposalDTO.java
@@ -1,0 +1,127 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+
+import org.iso.registry.api.IdentifiedItemProposalDTO;
+import org.iso.registry.core.model.IdentifiedItem;
+import org.iso.registry.core.model.IdentifiedItemWithObjectUsage;
+import org.iso.registry.core.model.ObjectDomain;
+import org.iso.registry.core.model.iso19115.extent.ExtentItem;
+import org.isotc211.iso19135.RE_RegisterItem_Type;
+
+import de.geoinfoffm.registry.api.RegisterItemProposalDTO;
+import de.geoinfoffm.registry.api.soap.AbstractIdentifiedItemProposal_Type;
+import de.geoinfoffm.registry.api.soap.Addition_Type;
+import de.geoinfoffm.registry.core.model.Proposal;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+import de.geoinfoffm.registry.core.model.iso19135.RE_SubmittingOrganization;
+
+/**
+ * Data transfer object for {@link IdentifiedItemWithObjectUsage} proposals
+ *
+ * @author Florian Esser
+ *
+ */
+public class IdentifiedItemWithObjectUsageProposalDTO extends IdentifiedItemProposalDTO
+{
+	private List<ObjectDomainProposalDTO> domains;
+
+	public IdentifiedItemWithObjectUsageProposalDTO() {
+		super();
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(AbstractIdentifiedItemProposal_Type itemDetails) {
+		super(itemDetails);
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(Addition_Type proposal, RE_SubmittingOrganization sponsor) {
+		super(proposal, sponsor);
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(IdentifiedItem item) {
+		super(item);
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(Proposal proposal) {
+		super(proposal);
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(RE_RegisterItem_Type item, RE_SubmittingOrganization sponsor) {
+		super(item, sponsor);
+	}
+
+	public IdentifiedItemWithObjectUsageProposalDTO(String itemClassName) {
+		super(itemClassName);
+	}
+
+	@Override
+	public List<RegisterItemProposalDTO> getAggregateDependencies() {
+		final List<RegisterItemProposalDTO> result = new ArrayList<RegisterItemProposalDTO>();
+		result.addAll(super.getAggregateDependencies());
+		for (ObjectDomainProposalDTO domain : this.getDomains()) {
+			result.add(domain.getDomainOfValidity());
+		}
+
+		return super.findDependentProposals((RegisterItemProposalDTO[])result.toArray(new RegisterItemProposalDTO[result.size()]));
+	}
+
+	@Override
+	public void setAdditionalValues(RE_RegisterItem registerItem, EntityManager entityManager) {
+		super.setAdditionalValues(registerItem, entityManager);
+
+		if (registerItem instanceof IdentifiedItemWithObjectUsage) {
+			IdentifiedItemWithObjectUsage item = (IdentifiedItemWithObjectUsage)registerItem;
+
+			List<ObjectDomain> domains = new ArrayList<>();
+			for (ObjectDomainProposalDTO domainDto : this.getDomains()) {
+				if (domainDto.getDomainOfValidity() == null) continue;
+
+				UUID referencedExtentUuid = domainDto.getDomainOfValidity().getReferencedItemUuid();
+				if (referencedExtentUuid == null) {
+					throw new RuntimeException(MessageFormat.format("Object domain does not reference an extent", referencedExtentUuid));
+				}
+
+				ExtentItem referencedExtent = entityManager.find(ExtentItem.class, referencedExtentUuid);
+				if (referencedExtent == null) {
+					throw new RuntimeException(MessageFormat.format("Referenced Extent '{0}' does not exist", referencedExtentUuid));
+				}
+
+				ObjectDomain domain = new ObjectDomain(domainDto.getScope(), referencedExtent);
+				domains.add(domain);
+			}
+			item.setDomains(domains);
+		}
+	}
+
+	@Override
+	public void loadAdditionalValues(RE_RegisterItem registerItem) {
+		super.loadAdditionalValues(registerItem);
+
+		if (registerItem instanceof IdentifiedItemWithObjectUsage) {
+			IdentifiedItemWithObjectUsage item = (IdentifiedItemWithObjectUsage)registerItem;
+
+			for (ObjectDomain domain : item.getDomains()) {
+				this.getDomains().add(new ObjectDomainProposalDTO(domain));
+			}
+		}
+	}
+
+	public Collection<ObjectDomainProposalDTO> getDomains() {
+		if (domains == null) {
+			domains = new ArrayList<>();
+		}
+		return domains;
+	}
+
+	public void setDomains(Collection<ObjectDomainProposalDTO> domains) {
+		this.domains = new ArrayList<>();
+		this.domains.addAll(domains);
+	}
+
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/IdentifiedItemWithObjectUsageViewBean.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/IdentifiedItemWithObjectUsageViewBean.java
@@ -1,0 +1,73 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.iso.registry.core.model.IdentifiedItemWithObjectUsage;
+import org.iso.registry.core.model.ObjectDomain;
+
+import de.geoinfoffm.registry.core.model.Appeal;
+import de.geoinfoffm.registry.core.model.Proposal;
+import de.geoinfoffm.registry.core.model.SimpleProposal;
+import de.geoinfoffm.registry.core.model.Supersession;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+
+/**
+ * View bean for {@link IdentifiedItemWithObjectUsage} objects
+ * 
+ * @author Florian Esser
+ *
+ */
+public class IdentifiedItemWithObjectUsageViewBean extends IdentifiedItemViewBean
+{
+	private List<ObjectDomainViewBean> domains;
+
+	public IdentifiedItemWithObjectUsageViewBean(Appeal appeal) {
+		super(appeal);
+	}
+
+	public IdentifiedItemWithObjectUsageViewBean(Proposal proposal) {
+		super(proposal);
+	}
+
+	public IdentifiedItemWithObjectUsageViewBean(RE_RegisterItem item, boolean loadDetails) {
+		super(item, loadDetails);
+	}
+
+	public IdentifiedItemWithObjectUsageViewBean(RE_RegisterItem item) {
+		super(item);
+	}
+
+	public IdentifiedItemWithObjectUsageViewBean(SimpleProposal proposal) {
+		super(proposal);
+	}
+
+	public IdentifiedItemWithObjectUsageViewBean(Supersession supersession) {
+		super(supersession);
+	}
+
+	public List<ObjectDomainViewBean> getDomains() {
+		if (domains == null) {
+			this.domains = new ArrayList<>();
+		}
+		return domains;
+	}
+
+	public void setDomains(List<ObjectDomainViewBean> domains) {
+		this.domains = domains;
+	}
+
+	@Override
+	protected void addAdditionalProperties(RE_RegisterItem registerItem, boolean loadDetails) {
+		super.addAdditionalProperties(registerItem, loadDetails);
+
+		if (registerItem instanceof IdentifiedItemWithObjectUsage) {
+			IdentifiedItemWithObjectUsage item = (IdentifiedItemWithObjectUsage)registerItem;
+
+			for (ObjectDomain domain : item.getDomains()) {
+				this.getDomains().add(new ObjectDomainViewBean(domain));
+			}
+		}
+	}
+
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ObjectDomainProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ObjectDomainProposalDTO.java
@@ -1,0 +1,43 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.util.Objects;
+
+import org.iso.registry.core.model.ObjectDomain;
+
+/**
+ * Data transfer object for {@link ObjectDomain} proposals
+ * 
+ * @author Florian Esser
+ *
+ */
+public class ObjectDomainProposalDTO
+{
+	private String scope;
+	private ExtentItemProposalDTO domainOfValidity;
+
+	public ObjectDomainProposalDTO() {
+	}
+
+	public ObjectDomainProposalDTO(ObjectDomain domain) {
+		Objects.requireNonNull(domain);
+
+		this.scope = domain.getScope();
+		this.domainOfValidity = new ExtentItemProposalDTO(domain.getDomainOfValidity());
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public ExtentItemProposalDTO getDomainOfValidity() {
+		return domainOfValidity;
+	}
+
+	public void setDomainOfValidity(ExtentItemProposalDTO domainOfValidity) {
+		this.domainOfValidity = domainOfValidity;
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ObjectDomainViewBean.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/ObjectDomainViewBean.java
@@ -1,0 +1,43 @@
+package org.iso.registry.api.registry.registers.gcp;
+
+import java.util.Objects;
+
+import org.iso.registry.core.model.ObjectDomain;
+
+/**
+ * View bean for {@link ObjectDomain}s
+ * 
+ * @author Florian Esser
+ *
+ */
+public class ObjectDomainViewBean
+{
+	private String scope;
+	private ExtentItemViewBean domainOfValidity;
+
+	public ObjectDomainViewBean() {
+	}
+
+	public ObjectDomainViewBean(ObjectDomain domain) {
+		Objects.requireNonNull(domain);
+
+		this.scope = domain.getScope();
+		this.domainOfValidity = new ExtentItemViewBean(domain.getDomainOfValidity());
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public ExtentItemViewBean getDomainOfValidity() {
+		return domainOfValidity;
+	}
+
+	public void setDomainOfValidity(ExtentItemViewBean domainOfValidity) {
+		this.domainOfValidity = domainOfValidity;
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/CoordinateOperationItemProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/CoordinateOperationItemProposalDTO.java
@@ -10,6 +10,7 @@ import javax.persistence.TypedQuery;
 
 import org.iso.registry.api.IdentifiedItemProposalDTO;
 import org.iso.registry.api.registry.registers.gcp.ExtentDTO;
+import org.iso.registry.api.registry.registers.gcp.IdentifiedItemWithObjectUsageProposalDTO;
 import org.iso.registry.api.registry.registers.gcp.UnitOfMeasureItemProposalDTO;
 import org.iso.registry.api.registry.registers.gcp.crs.CoordinateReferenceSystemItemProposalDTO;
 import org.iso.registry.core.model.UnitOfMeasureItem;
@@ -32,7 +33,7 @@ import de.geoinfoffm.registry.core.model.Proposal;
 import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
 import de.geoinfoffm.registry.core.model.iso19135.RE_SubmittingOrganization;
 
-public abstract class CoordinateOperationItemProposalDTO extends IdentifiedItemProposalDTO
+public abstract class CoordinateOperationItemProposalDTO extends IdentifiedItemWithObjectUsageProposalDTO
 {
 	private String operationVersion;
 	private ExtentDTO domainOfValidity;

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/CoordinateOperationItemViewBean.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/operation/CoordinateOperationItemViewBean.java
@@ -7,7 +7,7 @@ import org.iso.registry.api.AbstractCoordinateOperationItem_Type;
 import org.iso.registry.api.CoordinateReferenceSystemItem_PropertyType;
 import org.iso.registry.api.GcoConverter;
 import org.iso.registry.api.registry.registers.gcp.ExtentDTO;
-import org.iso.registry.api.registry.registers.gcp.IdentifiedItemViewBean;
+import org.iso.registry.api.registry.registers.gcp.IdentifiedItemWithObjectUsageViewBean;
 import org.iso.registry.api.registry.registers.gcp.UnitOfMeasureItemViewBean;
 import org.iso.registry.api.registry.registers.gcp.crs.CoordinateReferenceSystemItemViewBean;
 import org.iso.registry.core.model.UnitOfMeasureItem;
@@ -29,7 +29,7 @@ import de.geoinfoffm.registry.core.model.SimpleProposal;
 import de.geoinfoffm.registry.core.model.Supersession;
 import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
 
-public class CoordinateOperationItemViewBean extends IdentifiedItemViewBean
+public class CoordinateOperationItemViewBean extends IdentifiedItemWithObjectUsageViewBean
 {
 	private static final ObjectFactory gmdObjectFactory = new ObjectFactory(); 
 	

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/IdentifiedItemWithObjectUsage.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/IdentifiedItemWithObjectUsage.java
@@ -1,0 +1,52 @@
+package org.iso.registry.core.model;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.ElementCollection;
+import javax.persistence.MappedSuperclass;
+
+import org.hibernate.envers.Audited;
+
+import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
+import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
+import de.geoinfoffm.registry.core.model.iso19135.RE_Register;
+
+/**
+ * Base class for item classes that must implement the ObjectUsage interface
+ * 
+ * @author Florian Esser
+ *
+ */
+@Audited @MappedSuperclass
+public abstract class IdentifiedItemWithObjectUsage extends IdentifiedItem implements ObjectUsage
+{
+	@ElementCollection
+	private Set<ObjectDomain> domains;
+
+	public IdentifiedItemWithObjectUsage() {
+		super();
+	}
+
+	public IdentifiedItemWithObjectUsage(RE_Register register, RE_ItemClass itemClass, String name, String definition,
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation);
+
+		this.getDomains().addAll(domains);
+	}
+
+	@Override
+	public Collection<ObjectDomain> getDomains() {
+		if (domains == null) {
+			domains = new HashSet<>();
+		}
+		return domains;
+	}
+
+	@Override
+	public void setDomains(Collection<ObjectDomain> domains) {
+		this.domains = new HashSet<>();
+		this.domains.addAll(domains);
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/ObjectDomain.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/ObjectDomain.java
@@ -1,0 +1,47 @@
+package org.iso.registry.core.model;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import javax.persistence.ManyToOne;
+
+import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.iso19115.extent.ExtentItem;
+
+@Access(AccessType.FIELD)
+@Audited
+@Embeddable
+public class ObjectDomain
+{
+	@Column(columnDefinition = "text")
+	private String scope;
+
+	@ManyToOne(cascade = CascadeType.PERSIST)
+	private ExtentItem domainOfValidity;
+
+	protected ObjectDomain() {
+	}
+
+	public ObjectDomain(String scope, ExtentItem domainOfValidity) {
+		this.setScope(scope);
+		this.setDomainOfValidity(domainOfValidity);
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public ExtentItem getDomainOfValidity() {
+		return domainOfValidity;
+	}
+
+	public void setDomainOfValidity(ExtentItem domainOfValidity) {
+		this.domainOfValidity = domainOfValidity;
+	}
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/ObjectUsage.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/ObjectUsage.java
@@ -1,0 +1,10 @@
+package org.iso.registry.core.model;
+
+import java.util.Collection;
+
+public interface ObjectUsage
+{
+	Collection<ObjectDomain> getDomains();
+
+	void setDomains(Collection<ObjectDomain> domains);
+}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/ConcatenatedOperationItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/ConcatenatedOperationItem.java
@@ -1,6 +1,7 @@
 package org.iso.registry.core.model.operation;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.Access;
@@ -9,6 +10,7 @@ import javax.persistence.Entity;
 import javax.persistence.ManyToMany;
 
 import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.ObjectDomain;
 
 import de.geoinfoffm.registry.core.ItemClass;
 import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
@@ -28,8 +30,8 @@ public class ConcatenatedOperationItem extends CoordinateOperationItem
 	}
 
 	public ConcatenatedOperationItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
-		super(register, itemClass, name, definition, additionInformation);
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 	public List<SingleOperationItem> getCoordinateOperations() {

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/ConversionItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/ConversionItem.java
@@ -1,10 +1,13 @@
 package org.iso.registry.core.model.operation;
 
+import java.util.Collection;
+
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Entity;
 
 import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.ObjectDomain;
 
 import de.geoinfoffm.registry.core.ItemClass;
 import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
@@ -19,13 +22,11 @@ public class ConversionItem extends SingleOperationItem
 
 	protected ConversionItem() {
 		super();
-		// TODO Auto-generated constructor stub
 	}
 
 	public ConversionItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
-		super(register, itemClass, name, definition, additionInformation);
-		// TODO Auto-generated constructor stub
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 }

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/CoordinateOperationItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/CoordinateOperationItem.java
@@ -15,6 +15,9 @@ import javax.persistence.OneToMany;
 
 import org.hibernate.envers.Audited;
 import org.iso.registry.core.model.IdentifiedItem;
+import org.iso.registry.core.model.IdentifiedItemWithObjectUsage;
+import org.iso.registry.core.model.ObjectDomain;
+import org.iso.registry.core.model.ObjectUsage;
 import org.iso.registry.core.model.crs.CoordinateReferenceSystemItem;
 import org.iso.registry.core.model.iso19115.dataquality.DQ_PositionalAccuracy;
 import org.iso.registry.core.model.iso19115.extent.EX_Extent;
@@ -25,15 +28,17 @@ import de.geoinfoffm.registry.core.model.iso19135.RE_Register;
 
 @Access(AccessType.FIELD)
 @Audited @Entity
-public abstract class CoordinateOperationItem extends IdentifiedItem
+public abstract class CoordinateOperationItem extends IdentifiedItemWithObjectUsage
 {
 	private static final long serialVersionUID = -2482111385843464273L;
 
 	private String operationVersion;
-	
+
+	@Deprecated
 	@ManyToOne(cascade = CascadeType.ALL)
 	private EX_Extent domainOfValidity;
 	
+	@Deprecated
 	@ElementCollection
 	private List<String> scope;
 	
@@ -50,9 +55,9 @@ public abstract class CoordinateOperationItem extends IdentifiedItem
 	}
 
 	public CoordinateOperationItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
 
-		super(register, itemClass, name, definition, additionInformation);
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 	public String getOperationVersion() {
@@ -63,22 +68,27 @@ public abstract class CoordinateOperationItem extends IdentifiedItem
 		this.operationVersion = operationVersion;
 	}
 
+	@Deprecated
 	public EX_Extent getDomainOfValidity() {
 		return domainOfValidity;
 	}
-
+	
+	@Deprecated
 	public void setDomainOfValidity(EX_Extent domainOfValidity) {
 		this.domainOfValidity = domainOfValidity;
 	}
 
+	@Deprecated
 	public List<String> getScope() {
 		return scope;
 	}
 	
+	@Deprecated
 	public void setScope(List<String> scope) {
 		this.scope = scope;
 	}
 	
+	@Deprecated
 	public void addScope(String scope) {
 		if (this.scope == null) {
 			this.scope = new ArrayList<>();
@@ -86,6 +96,7 @@ public abstract class CoordinateOperationItem extends IdentifiedItem
 		this.scope.add(scope);
 	}
 
+	@Deprecated
 	public void addScopes(Collection<String> scopes) {
 		if (this.scope == null) {
 			this.scope = new ArrayList<>();

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/PassThroughOperationItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/PassThroughOperationItem.java
@@ -1,8 +1,11 @@
 package org.iso.registry.core.model.operation;
 
+import java.util.Collection;
+
 import javax.persistence.Entity;
 
 import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.ObjectDomain;
 
 import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
 import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
@@ -16,8 +19,8 @@ public class PassThroughOperationItem extends CoordinateOperationItem
 	}
 
 	public PassThroughOperationItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
-		super(register, itemClass, name, definition, additionInformation);
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 }

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/SingleOperationItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/SingleOperationItem.java
@@ -1,6 +1,7 @@
 package org.iso.registry.core.model.operation;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.persistence.Access;
@@ -13,6 +14,7 @@ import javax.persistence.ManyToOne;
 
 import org.apache.commons.collections.iterators.AbstractListIteratorDecorator;
 import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.ObjectDomain;
 
 import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
 import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
@@ -30,13 +32,11 @@ public abstract class SingleOperationItem extends CoordinateOperationItem
 
 	protected SingleOperationItem() {
 		super();
-		// TODO Auto-generated constructor stub
 	}
 
 	public SingleOperationItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
-		super(register, itemClass, name, definition, additionInformation);
-		// TODO Auto-generated constructor stub
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 	public OperationMethodItem getMethod() {

--- a/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/TransformationItem.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/core/model/operation/TransformationItem.java
@@ -1,10 +1,13 @@
 package org.iso.registry.core.model.operation;
 
+import java.util.Collection;
+
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Entity;
 
 import org.hibernate.envers.Audited;
+import org.iso.registry.core.model.ObjectDomain;
 
 import de.geoinfoffm.registry.core.ItemClass;
 import de.geoinfoffm.registry.core.model.iso19135.RE_AdditionInformation;
@@ -19,13 +22,11 @@ public class TransformationItem extends SingleOperationItem
 
 	protected TransformationItem() {
 		super();
-		// TODO Auto-generated constructor stub
 	}
 
 	public TransformationItem(RE_Register register, RE_ItemClass itemClass, String name, String definition,
-			RE_AdditionInformation additionInformation) {
-		super(register, itemClass, name, definition, additionInformation);
-		// TODO Auto-generated constructor stub
+			RE_AdditionInformation additionInformation, Collection<ObjectDomain> domains) {
+		super(register, itemClass, name, definition, additionInformation, domains);
 	}
 
 }

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
@@ -303,6 +303,7 @@ public class DataController
 			model.addAttribute("objectPath", objectPath);
 		}
 		model.addAttribute("isProposal", "true");
+		model.addAttribute("useWeakBinding", "true");
 		return "registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(index='" + index + "')";
 	}
 

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
@@ -294,6 +294,17 @@ public class DataController
 		return "registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(index='" + index + "')";
 	}
 
+	@RequestMapping(value = "/fragments/objectusage")
+	public String getObjectUsageFragment(@RequestParam("index") String index, @RequestParam(value = "objectPath", required = false) String objectPath, final Model model) {
+		if (!StringUtils.isEmpty(objectPath)) {
+			model.addAttribute("objectPath", objectPath);
+		}
+
+		model.addAttribute("isProposal", "true");
+		model.addAttribute("useWeakBinding", "true");
+		return "registry/registers/gcp/objectusage_panel_content :: objectUsagePanelContent(index='" + index + "')";
+	}
+
 	@RequestMapping(value = "/fragments/citationpopup")
 	public String getCitationPopupFragment(@RequestParam("index") String index, @RequestParam(value = "objectPath", required = false) String objectPath, final Model model) {
 		if (!StringUtils.isEmpty(objectPath)) {

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/DataController.java
@@ -64,16 +64,28 @@ public class DataController
 	public @ResponseBody List<Object[]> findAll(@PathVariable("className") String className, 
 												@RequestParam(value = "orderBy", defaultValue = "name") String orderBy,
 												@RequestParam(value = "where", required = false) String where,
-												@RequestParam(value = "q", required = false) String search) {
+												@RequestParam(value = "q", required = false) String search,
+												@RequestParam(value = "isIdentifiedItem", defaultValue = "true") boolean isIdentifiedItem) {
 		StringBuilder q = new StringBuilder();
 		if (StringUtils.isEmpty(orderBy) || "null".equals(orderBy)) {
 			orderBy = "name";
 		}
 		
-		q.append("SELECT i.uuid, i.identifier, i.name, i.description FROM " + className + " i WHERE i.status = 'VALID'");
+		q.append("SELECT i.uuid, ");
+		if (isIdentifiedItem) {
+			q.append("i.identifier, ");
+		}
+		else {
+			q.append("-1 AS identifier, ");
+		}
+		q.append("i.name, i.description FROM " + className + " i WHERE i.status = 'VALID'");
+
 		if (!StringUtil.isEmpty(search)) {
 			search = "%" + search + "%";
-			q.append(" AND (LOWER(i.name) LIKE '" + search.toLowerCase() + "' OR CAST(i.identifier AS text) LIKE '" + search + "')");
+			q.append(" AND (LOWER(i.name) LIKE '" + search.toLowerCase() + "')");
+			if (isIdentifiedItem) {
+				q.append(" OR CAST(i.identifier AS text) LIKE '" + search + "')");
+			}
 		}
 		if (!StringUtils.isEmpty(where)) {
 			q.append(" AND (");

--- a/src/iso-registry-client/src/main/resources/i18n/messages.xml
+++ b/src/iso-registry-client/src/main/resources/i18n/messages.xml
@@ -88,6 +88,7 @@
 	<entry key="tableheader.citation">Citation</entry>
 	<entry key="tableheader.scope">Scope</entry>
 	<entry key="tableheader.ticket">Related issue</entry>
+	<entry key="tableheader.objectUsage">Object usage</entry>
 
 	<entry key="header.supersededItems">Superseded items</entry>	
 	<entry key="header.supersedingItems">Successors</entry>
@@ -140,6 +141,7 @@
 	<entry key="header.ungroupedProposals">Ungrouped proposals that may be added</entry>
 	<entry key="header.groupProposal">Group proposal</entry>
 	<entry key="header.terms">Terms of Use</entry>
+	<entry key="header.objectUsage">Object usage</entry>
 	
 	<entry key="button.reviewProposal">Review</entry>
 	<entry key="button.decideProposal">Decide</entry>
@@ -474,6 +476,7 @@
 	<entry key="form.label.horizontalCrs">Horizontal CRS</entry>
 	<entry key="form.label.verticalCrs">Vertical CRS</entry>
 	<entry key="form.label.selectExtent">Import existing extent</entry>
+	<entry key="form.label.selectExtentItem">Extent</entry>
 	<entry key="form.label.autoAssigned">Will be assigned automatically</entry>
 	<entry key="form.label.title">Title</entry>
 	<entry key="form.label.alternateTitle">Alternate title</entry>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
@@ -30,18 +30,41 @@
 
 <div th:fragment="textField (property, inputType, label, placeholder, isRequired)" class="form-group" th:classappend="${isRequired} ? 'has-feedback'">
 	<div th:replace="globals :: formLabel(${property}, ${label})"/>
-	<input th:unless="${objectPath}" th:if="!${isReadOnly} and ${isProposal}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:step="${step}" th:field="*{__${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
-	<p th:unless="${objectPath}" th:if="${isReadOnly} or !${isProposal}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}"><big th:text="*{__${property}__}"/></p>
-	<input th:if="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:name="${objectPath} + '.' + ${property}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
+	<th:block th:if="!${isReadOnly} and ${isProposal}">
+		<th:block th:if="${useWeakBinding}">
+			<input th:if="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:name="${objectPath} + '.' + ${property}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
+			<input th:unless="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:name="${property}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
+		</th:block>
+		<th:block th:unless="${useWeakBinding}">
+			<input th:if="${objectPath}" th:id="${modifier} ? ${objectPath} + '-' + ${property} + '-' + ${modifier} : ${objectPath} + '-' + ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:step="${step}" th:field="*{__${objectPath} + '.' + ${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
+			<input th:unless="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:type="${inputType}" th:step="${step}" th:field="*{__${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"></input>
+		</th:block>
+	</th:block>
+	<th:block th:unless="!${isReadOnly} and ${isProposal}">
+		<p th:if="${objectPath}" th:id="${modifier} ? ${objectPath} + '-' + ${property} + '-' + ${modifier} : ${objectPath} + '-' + ${property}"><big th:text="*{____${objectPath} + '.' + ${property}__}"/></p>
+		<p th:unless="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}"><big th:text="*{__${property}__}"/></p>
+	</th:block>
 	<span th:if="${isProposal} and ${isRequired}" class="feedback glyphicon glyphicon-hand-left form-control-feedback" th:title="#{mandatoryField}"></span>
 </div>
 
 <!-- Parameters: property, rows, cols, inputType, label, placeholder, isRequired -->
 <div th:fragment="textArea" class="form-group" th:classappend="${isRequired} ? 'has-feedback'"> 
 	<div th:replace="globals :: formLabel(${property}, ${label})"/>
-	<textarea th:unless="${objectPath}" th:if="!${isReadOnly} and ${isProposal}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:field="*{__${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
-	<p th:unless="${objectPath}" th:if="${isReadOnly} or !${isProposal}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}"><big th:text="*{__${property}__}"/></p>
-	<textarea th:if="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${objectPath} + '.' + ${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:readonly="${isReadOnly}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
+	<th:block th:if="!${isReadOnly} and ${isProposal}">
+		<th:block th:if="${useWeakBinding}">
+			<textarea th:if="!${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
+			<textarea th:if="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${objectPath} + '.' + ${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
+		</th:block>
+		<th:block th:unless="${useWeakBinding}">
+			<textarea th:if="!${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:field="*{__${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
+			<textarea th:if="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}" th:name="${objectPath} + '.' + ${property}" th:rows="${rows}" th:cols="${cols}" th:placeholder="${placeholder}" class="form-control" th:classappend="${isRequired} ? 'required'" th:required="${isRequired}" th:field="*{__${objectPath} + '.' + ${property}__}" th:attr="data-label=${label},data-label-parent=${parentLabel}"/>
+		</th:block>
+	</th:block>
+	<th:block th:unless="!${isReadOnly} and ${isProposal}">
+		<p th:if="${objectPath}" th:id="${modifier} ? ${objectPath} + '-' + ${property} + '-' + ${modifier} : ${objectPath} + '-' + ${property}"><big th:text="*{__${objectPath} + '.' + ${property}__}"/></p>
+		<p th:unless="${objectPath}" th:id="${modifier} ? ${property} + '-' + ${modifier} : ${property}"><big th:text="*{__${property}__}"/></p>
+	</th:block>
+
 	<span th:if="${isProposal} and ${isRequired}" class="feedback glyphicon glyphicon-hand-left form-control-feedback" th:title="#{mandatoryField}"></span>
 </div>
 
@@ -150,9 +173,10 @@
 
 <div th:fragment="selectIdentifiedItem2" class="form-group">
 	<div th:replace="globals :: formLabel(${property}, ${label})"/>
-	<div th:if="${isProposal}" th:id="${property} + 'Group'" th:with="isClarification=${proposal.isClarification()}">
-		<input type="hidden" th:id="${property}" style="width: 100%" th:field="*{__${property}__.referencedItemUuid}" th:required="${isRequired}"/>
-		<script type="text/javascript" charset="utf-8" th:inline="text">
+	<div th:if="${isProposal}" th:id="${property} + 'Group'">
+		<input th:unless="${useWeakBinding}" type="hidden" th:id="${property}" style="width: 100%" th:field="*{__${property}__.referencedItemUuid}" th:required="${isRequired}"/>
+		<input th:if="${useWeakBinding}" type="hidden" th:id="${property}" class="select-identified-item" style="width: 100%" th:name="__${property}__.referencedItemUuid" th:required="${isRequired}" th:attr="data-ajax-path='__${ajaxPath}__',data-base-path='__${basePath}__'"/>
+		<script th:id="'select2-' + ${property}" type="text/javascript" charset="utf-8" th:inline="text">
 		/* <![CDATA[ */
 			$(function() {
 				$('#[[${property}]]').select2({
@@ -197,7 +221,7 @@
 		            }						            
 		        });
 				
-				if ([[${proposal.isClarification()}]]) {
+				if ([[${isClarification}]]) {
 					$('#[[${property}]]').select2("readonly", true);
 				}
 			});

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
@@ -71,6 +71,83 @@
 	
 </div>
 
+<div th:fragment="selectRegisterItem" class="form-group">
+	<div th:replace="globals :: formLabel(${property}, ${label})"/>
+	<div th:if="${isProposal}" th:id="${property} + 'Group'">
+		<th:block th:if="${objectPath}">
+			<input th:if="${useWeakBinding}" type="hidden" class="select-register-item" style="width: 100%" th:name="__${objectPath}__.__${property}__.referencedItemUuid" th:required="${isRequired}" th:attr="data-property=${property},data-ajax-path='__${ajaxPath}__'"/>
+			<input th:unless="${useWeakBinding}" type="hidden" class="select-register-item" style="width: 100%" th:field="*{__${objectPath} + '.' + ${property}__.referencedItemUuid}" th:required="${isRequired}" th:attr="data-property=${property},data-ajax-path='__${ajaxPath}__'"/>
+		</th:block>
+		<th:block th:unless="${objectPath}">
+			<input th:if="${useWeakBinding}" type="hidden" th:id="${property}" class="select-register-item" style="width: 100%" th:name="__${property}__.referencedItemUuid" th:required="${isRequired}" th:attr="data-property=${property},data-ajax-path='__${ajaxPath}__'"/>
+			<input th:unless="${useWeakBinding}" type="hidden" th:id="${property}" th:attr="data-property=${property}" class="select-register-item" style="width: 100%" th:field="*{__${property}__.referencedItemUuid}" th:required="${isRequired}"/>
+		</th:block>
+		<script th:id="'select2-' + ${property}" type="text/javascript" charset="utf-8" th:inline="text">
+		/* <![CDATA[ */
+			$(function() {
+				$('.select-register-item').select2({
+					multiple: false,
+					dropdownCssClass: "bigdrop",
+					ajax: {
+						url: "[[@{__${basePath}__/}]]entities/by-class/[[${ajaxPath}]]",
+						dataType: "json",
+						data: function(term, page) {
+							return {
+								orderBy: 'name',
+								q: term,
+								isIdentifiedItem: 'false',
+								where: "[[${where} ? ${where} : '']]"
+							};
+						},
+						results: function (data) {
+							return {
+								results : $.map(data, function (item) {
+									return {
+										id: item[0],
+										text: item[2],
+									}
+								})
+							};
+						}
+					},
+					initSelection: function(element, callback) {
+						var result = [];
+						// Collect AJAX requests needed to resolve initially
+						// selected items
+						$.when($.ajax("[[@{__${basePath}__/}]]entities/by-uuid/" + $(element).val(), {
+							dataType: "json"
+						}))
+						.done(function(data) {
+							item = data[0];
+							result.push({
+								id: item[0],
+								text: item[2],
+							});
+							callback(result[0]);
+						});
+					}
+				});
+
+				if ([[${isClarification}]]) {
+					$('#[[${property}]]').select2("readonly", true);
+				}
+			});
+
+		/* ]]> */
+		</script>
+	</div>
+	<div th:unless="${isProposal}">
+		<!-- form-backing bean: RegisterItemViewBean -->
+		<div th:if="*{__${property}__}" th:with="uuid=*{__${property}__.uuid}">
+			<a th:href="@{__${basePath}__/item/__${uuid}__}" th:title="*{__${property}__.name}"><big th:text="*{__${property}__.name}"/></a>&nbsp;<big class="text-muted" th:text="'[' + *{__${property}__.itemIdentifier} + ']'"/>
+		</div>
+		<div th:unless="*{__${property}__}">
+			<big>[<span class="text-muted" th:text="#{undefined}"></span>]</big>
+		</div>
+	</div>
+
+</div>
+
 <div th:fragment="selectIdentifiedItem2" class="form-group">
 	<div th:replace="globals :: formLabel(${property}, ${label})"/>
 	<div th:if="${isProposal}" th:id="${property} + 'Group'" th:with="isClarification=${proposal.isClarification()}">
@@ -484,6 +561,39 @@
 		/* ]]> */
 		</script>
 	</div>	
+</div>
+
+<!-- Table showing the object usage, i.e. the scopes with their respective extents -->
+<div th:fragment="domainsTable(modifier)">
+	<div class="col-md-12" th:unless="!*{domains} or ${isProposal}">
+		<div class="panel">
+			<div class="panel-body">
+				<table th:id="'domainsTable_' + ${modifier}" class="datatable table table-condensed table-striped">
+					<thead>
+						<tr>
+							<th th:text="#{tableheader.scope}" />
+							<th th:text="#{form.label.northernLatitude}" />
+							<th th:text="#{form.label.easternLongitude}" />
+							<th th:text="#{form.label.southernLatitude}" />
+							<th th:text="#{form.label.westernLongitude}" />
+						</tr>
+					</thead>
+					<tbody>
+						<th:block th:each="domain : *{domains}">
+							<tr th:each="gbb,iterStat : ${domain.domainOfValidity.geographicBoundingBoxes}">
+								<td th:if="${iterStat.first}" th:rowspan="${domain.domainOfValidity.geographicBoundingBoxes.size()}" th:text="${domain.scope}" />
+								<td th:text="${gbb.northBoundLatitude}" />
+								<td th:text="${gbb.eastBoundLongitude}" />
+								<td th:text="${gbb.southBoundLatitude}" />
+								<td th:text="${gbb.westBoundLongitude}" />
+							</tr>
+						</th:block>
+					</tbody>
+				</table>
+				<button th:if="${isProposal} and !${proposal.isClarification()}" th:id="'addScope_' + ${modifier}" type="button" th:attr="data-modifier=${modifier}" th:text="#{button.addScope}" class="btn btn-sm btn-default button-addalias">Add new</button>
+			</div>
+		</div>
+	</div>
 </div>
 
 <div th:fragment="scopeTable(modifier)">

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/create_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/create_item.html
@@ -36,6 +36,9 @@
 							<div th:if="${showExtentPanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/extent_panel :: extentDetailsPanel"/>
 							</div>
+							<div th:if="${showObjectUsagePanel}" th:unless="${proposal.isClarification()}">
+								<div th:replace="registry/registers/gcp/objectusage_panel :: objectUsageDetailsPanel"/>
+							</div>
 							<div th:if="${showInformationSourcePanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/infosrc_panel :: informationSourceDetailsPanel"/>
 							</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/edit_item.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/edit_item.html
@@ -36,6 +36,9 @@
 							<div th:if="${showExtentPanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/extent_panel :: extentDetailsPanel"/>
 							</div>
+							<div th:if="${showObjectUsagePanel}" th:unless="${proposal.isClarification()}">
+								<div th:replace="registry/registers/gcp/objectusage_panel :: objectUsageDetailsPanel"/>
+							</div>
 							<div th:if="${showInformationSourcePanel}" th:unless="${proposal.isClarification()}">
 								<div th:replace="registry/registers/gcp/infosrc_panel :: informationSourceDetailsPanel"/>
 							</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_create_addition.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
+<html xmlns="http://www.w3.org/1999/xhtml" th:with="showObjectUsagePanel='true'">
 <head th:include="layout :: headerFragment" />
 <body th:include="registry/registers/create_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
@@ -4,11 +4,6 @@
 			<div class="row" th:include="globals :: nameAndIdentifier" />
 			<div class="row" th:include="globals :: registerItemDefinition"/>
 			<div class="row" th:include="globals :: aliasesTable('conv')" />
-			<div class="row" th:if="!${isProposal} or ${proposal.isClarification()}">
-				<div class="col-md-12">
-					<div th:replace="registry/registers/gcp/extent_panel :: extentDetails"/>
-				</div>
-			</div>
 			<div class="row">
 				<div class="col-md-4" th:with="property='accuracy',inputType='number',label=#{form.label.accuracy},placeholder=#{form.placeholder.accuracy},isRequired='false'">
 					<div th:replace="globals :: textField(${property}, ${inputType}, ${label}, ${placeholder}, ${isRequired})"/>
@@ -88,12 +83,12 @@
 		</div>	<!-- END OF LEFT -->
 		
 		<div class="col-md-6"> <!-- RIGHT -->
-			<div class="row" th:include="globals :: scopeTable('conversion')" />
 			<div class="row" th:include="globals :: remarks (cssClass='col-md-12')" />
 			<div class="row" th:include="globals :: informationSource (cssClass='col-md-12')" />
 			<div class="row" th:include="globals :: dataSource (cssClass='col-md-12')" />
 		</div>	<!-- END OF RIGHT -->
 	</div>
+	<div class="row" th:if="!${isProposal} or ${proposal.isClarification()}" th:include="globals :: domainsTable('conversion')" />
 	<div class="row">
 		<div class="col-md-12">
 			<table id="parametersTable" class="table table-striped">

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_edit_addition.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
+<html xmlns="http://www.w3.org/1999/xhtml" th:with="showObjectUsagePanel='true'">
 <head th:include="layout :: headerFragment" />
 <body th:include="registry/registers/edit_item :: body(#{header.conversion}, 'registry/registers/gcp/conv_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/objectusage_panel.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/objectusage_panel.html
@@ -1,0 +1,102 @@
+<div th:fragment="objectUsageDetailsPanel" id="objectUsageDetailsPanel" class="panel panel-default" th:if="${itemClass}">
+	<div class="panel-heading">
+		<a data-toggle="collapse" data-parent="#accordion" href="#objectUsagePanel"><span class="panel-title" th:text="#{header.objectUsage}"></span></a>
+	</div>
+	<div id="objectUsagePanel" class="panel-collapse">
+		<ul id="objusage-tabs" class="nav nav-tabs">
+			<li th:each="usage,rowStat : *{domains}" th:classappend="(${rowStat.index} eq 0) ? 'active'" th:id="'li-objusage-' + ${rowStat.index}" th:attr="data-index=${rowStat.index}">
+				<a th:href="'#objusage-' + ${rowStat.index}" data-toggle="tab">
+					<span th:text="'Object usage #' + (${rowStat.index} + 1)"></span>
+					<button th:if="${isProposal} and !${isReadOnly}" th:id="'delete-objusage-' + ${rowStat.index}" type="button" th:attr="data-index=${rowStat.index}" class="btn btn-xs btn-default button-close-objusage"><span class="fa fa-times"></span></button>
+				</a>
+			</li>
+			<li th:unless="${isReadOnly}" id="li-addobjectusage"><a id="button-addobjectusage" href="#"><span class="fa fa-plus"></span>&nbsp;&nbsp;<span th:text="#{button.addNew}"></span></a></li>
+		</ul>
+		<div class="tab-content">
+			<div th:each="usage,rowStat : *{domains}" th:classappend="(${rowStat.index} eq 0) ? 'active'" th:id="'objusage-' + ${rowStat.index}" class="tab-pane in" style="padding-top: 10px">
+				<div class="panel-body" th:with="objectPath='domains[__${rowStat.index}__]'">
+					<div th:replace="registry/registers/gcp/objectusage_panel_content :: objectUsagePanelContent(__${rowStat.index}__)"/>
+				</div>
+			</div>
+			<div id="objusage-tabs-after"/>
+		</div>
+
+		<script type="text/javascript" th:inline="text">
+		/* <![CDATA[ */
+			$('#button-addobjectusage').click(function(e) {
+				e.preventDefault();
+				var idx = $('#li-addobjectusage').prev().data('index');
+				if (idx === null) {
+					idx = 0;
+				}
+				else {
+					idx += 1;
+				}
+				$('<li id="li-objusage-' + idx + '" data-index="' + idx + '"><a id="show-objusage-' + idx + '" href="#objusage-' + idx + '" data-toggle="tab">Object usage #' + (idx + 1) + ' <button id="delete-objusage-' + idx + '" type="button" data-index="' + idx + '" class="btn btn-xs btn-default button-close-objusage"><span class="fa fa-times"></span></button></a></li>').insertBefore('#li-addobjectusage');
+
+				$('<div id="objusage-' + idx + '" class="tab-pane" style="padding-top: 10px"/>').insertBefore('#objusage-tabs-after');
+				$('#objusage-' + idx).append('<div id="objusage-' + idx + '-content" class="panel-body"/>');
+				$('#objusage-' + idx + '-content').load('[[@{__${basePath}__/entities/fragments/objectusage}]]?index=' + idx + '&objectPath=domains%5B' + idx + '%5D', null, function() {
+					$('.select-register-item').each(function() {
+						$(this).select2({
+							multiple: false,
+							dropdownCssClass: "bigdrop",
+							ajax: {
+								url: "[[@{__${basePath}__/}]]entities/by-class/" + $(this).data('ajax-path'),
+								dataType: "json",
+								data: function(term, page) {
+									return {
+										orderBy: 'name',
+										q: term,
+										isIdentifiedItem: 'false',
+										where: "[[${where} ? ${where} : '']]"
+									};
+								},
+								results: function (data) {
+									return {
+										results : $.map(data, function (item) {
+											return {
+												id: item[0],
+												text: item[2],
+											}
+										})
+									};
+								}
+							},
+							initSelection: function(element, callback) {
+								var result = [];
+								// Collect AJAX requests needed to resolve initially
+								// selected items
+
+								$.when($.ajax("[[@{__${basePath}__/}]]entities/by-uuid/" + $(element).val(), {
+									dataType: "json"
+								}))
+									.done(function(data) {
+										item = data[0];
+										result.push({
+										id: item[0],
+										text: item[2],
+									});
+									callback(result[0]);
+								});
+							}
+						});
+					});
+				});
+
+				$('#show-objusage-' + idx).tab('show');
+			});
+
+			$('body').on('click', '.button-close-objusage', function() {
+				var idx = $(this).data('index');
+				$('#li-objusage-' + idx).remove();
+				$('#objusage-' + idx).remove();
+				var first = $('#objusage-tabs').find('li:first').data('index');
+				if (first !== null) {
+					$('#show-objusage-' + first).tab('show');
+				}
+			});
+		/* ]]> */
+		</script>
+	</div>
+</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/objectusage_panel_content.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/objectusage_panel_content.html
@@ -1,0 +1,15 @@
+<div th:fragment="objectUsagePanelContent(index)">
+	<div th:if="${isProposal} and !${isReadOnly}">
+		<div class="row">
+			<div class="col-md-12" th:with="property='domainOfValidity',label=#{form.label.selectExtentItem},isRequired='true',noAddNew='true',ajaxPath='ExtentItem'">
+				<div th:replace="globals :: selectRegisterItem" />
+			</div>
+		</div>
+
+		<div class="row">
+			<div class="col-md-12" th:with="property='scope',inputType='text',label=#{form.label.scope},placeholder=#{form.placeholder.scope},isRequired='true'">
+				<div th:replace="globals :: textArea" />
+			</div>
+		</div>
+	</div>
+</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_create_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_create_addition.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
+<html xmlns="http://www.w3.org/1999/xhtml" th:with="showObjectUsagePanel='true'">
 <head th:include="layout :: headerFragment" />
 <body th:include="registry/registers/create_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')" th:with="showInformationSourcePanel='true'"/>
 </html>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
@@ -1,14 +1,9 @@
-<div th:fragment="details">
+<div th:fragment="details" th:with="isClarification=${isProposal} ? ${proposal.isClarification()} : 'false'">
 	<div class="row">
 		<div class="col-md-6"> <!-- LEFT -->
 			<div class="row" th:include="globals :: nameAndIdentifier" />
 			<div class="row" th:include="globals :: registerItemDefinition"/>
 			<div class="row" th:include="globals :: aliasesTable('conv')" />
-			<div class="row" th:if="!${isProposal} or ${proposal.isClarification()}">
-				<div class="col-md-12" th:with="isClarification=${isProposal} ? ${proposal.isClarification()} : 'false'">
-					<div th:replace="registry/registers/gcp/extent_panel :: extentDetails"/>
-				</div>
-			</div>
 			<div class="row">
 				<div class="col-md-12" th:with="property='sourceCrs',label=#{form.label.sourceCrs},isRequired='true',noAddNew='true',ajaxPath='CoordinateReferenceSystemItem'">
 					<div th:replace="globals :: selectIdentifiedItem2"/>
@@ -103,12 +98,12 @@
 		</div>	<!-- END OF LEFT -->
 		
 		<div class="col-md-6"> <!-- RIGHT -->
-			<div class="row" th:include="globals :: scopeTable('transformation')" />
 			<div class="row" th:include="globals :: remarks (cssClass='col-md-12')" />
 			<div class="row" th:include="globals :: informationSource (cssClass='col-md-12')" />
 			<div class="row" th:include="globals :: dataSource (cssClass='col-md-12')" />
 		</div>	<!-- END OF RIGHT -->
 	</div>
+	<div class="row" th:if="!${isProposal} or ${proposal.isClarification()}" th:include="globals :: domainsTable('transformation')" />
 	<div class="row">
 		<div class="col-md-12">
 			<table id="parametersTable" class="table table-striped">

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_edit_addition.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_edit_addition.html
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" th:with="showExtentPanel='true'">
+<html xmlns="http://www.w3.org/1999/xhtml" th:with="showObjectUsagePanel='true'">
 <head th:include="layout :: headerFragment" />
 <body th:include="registry/registers/edit_item :: body(#{header.transformation}, 'registry/registers/gcp/trans_details')" th:with="showInformationSourcePanel='true'"/>
 </html>


### PR DESCRIPTION
Migrates the item classes `Conversion` and `Transformation` to the new `ObjectUsage` interface as defined in ISO 19111:2019. Previous attributes are retained for backwards compatibility for
the time being but are marked as deprecated.

https://github.com/ISO-TC211/iso-geodetic-registry/issues/51