### PR TITLE
Changes and fixes concerning among others the register item list and invalidated items

### DIFF
--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/RegisterController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/RegisterController.java
@@ -401,7 +401,8 @@ public class RegisterController extends AbstractController
 		}
 		model.addAttribute("register", register);
 
-		List<RE_RegisterItem> items = itemRepository.findByRegisterAndItemIdentifierAndStatusIn(register, itemIdentifier, Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.SUPERSEDED, RE_ItemStatus.RETIRED));
+		List<RE_RegisterItem> items = itemRepository.findByRegisterAndItemIdentifierAndStatusIn(register, itemIdentifier,
+				Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.SUPERSEDED, RE_ItemStatus.RETIRED, RE_ItemStatus.INVALID));
 		if (items.isEmpty()) {
 			throw new ItemNotFoundException(register, itemIdentifier);
 		}
@@ -1232,7 +1233,7 @@ public class RegisterController extends AbstractController
 
 		List<RE_ItemStatus> acceptedStatus;
 		if (status == null) {
-			acceptedStatus = Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.RETIRED, RE_ItemStatus.SUPERSEDED);
+			acceptedStatus = Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.RETIRED, RE_ItemStatus.SUPERSEDED, RE_ItemStatus.INVALID);
 		}
 		else {
 			acceptedStatus = Arrays.asList(status);
@@ -1268,8 +1269,8 @@ public class RegisterController extends AbstractController
 					.createQuery()
 					.forEntitiesAtRevision(RE_RegisterItem.class, revision)
 					.add(AuditEntity.property("register").eq(register))
-					.add(AuditEntity.property("status")
-							.in(Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.RETIRED, RE_ItemStatus.SUPERSEDED)));
+					.add(AuditEntity.property("status").in(
+							Arrays.asList(RE_ItemStatus.VALID, RE_ItemStatus.RETIRED, RE_ItemStatus.SUPERSEDED, RE_ItemStatus.INVALID)));
 
 			if (!StringUtils.isEmpty(sSearch)) {
 				aq = aq.add(AuditEntity.or(AuditEntity.property("name").ilike("%" + sSearch + "%"),

--- a/src/iso-registry-client/src/main/resources/i18n/messages.xml
+++ b/src/iso-registry-client/src/main/resources/i18n/messages.xml
@@ -226,6 +226,7 @@
 
 	<entry key="NOT_VALID">not valid</entry>
 	<entry key="VALID">valid</entry>
+	<entry key="INVALID">invalid</entry>
 	<entry key="SUPERSEDED">superseded</entry>
 	<entry key="RETIRED">retired</entry>
 	

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
@@ -127,7 +127,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" id="addtogroup-' + item.proposalUuid + '" class="btn btn-success button-addtogroup" disabled="disabled" data-uuid="' + item.proposalUuid + '">[[#{button.addToGroup}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -151,7 +151,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" id="doremovefromgroup-' + item.proposalUuid + '" class="btn btn-danger button-doremovefromgroup" data-uuid="' + item.proposalUuid + '">[[#{button.removeFromGroup}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -182,7 +182,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-danger button-dissolvegroup" data-uuid="' + item.proposalUuid + '">[[#{button.dissolveGroup}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -206,7 +206,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-' + okType + ' button-popup-' + action + '" data-uuid="' + itemUuid + '">' + okText + '</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="[[#{button.cancel}]]">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -230,7 +230,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-success button-submitproposal" data-uuid="' + item.proposalUuid + '">[[#{button.submitProposal}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -254,7 +254,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-withdrawproposal" data-uuid="' + item.proposalUuid + '">[[#{button.withdrawProposal}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -278,7 +278,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-danger button-deleteproposal" data-uuid="' + item.proposalUuid + '">[[#{button.deleteProposal}]]</button>' +
-							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -302,7 +302,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-startdiscussion" data-uuid="' + item.proposalUuid + '">[[#{button.startProposalDiscussion}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -326,7 +326,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-enddiscussion" data-uuid="' + item.proposalUuid + '">[[#{button.endProposalDiscussion}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -350,7 +350,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-startballot" data-uuid="' + item.proposalUuid + '">[[#{button.startProposalBallot}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -374,7 +374,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-endballot" data-uuid="' + item.proposalUuid + '">[[#{button.endProposalBallot}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -398,7 +398,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-warning button-endappeal" data-uuid="' + item.proposalUuid + '">[[#{button.endAppealPeriod}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -422,7 +422,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-success button-acceptappeal" data-uuid="' + item.proposalUuid + '">[[#{button.acceptAppeal}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +
@@ -446,7 +446,7 @@
 						'</div>' +
 						'<div class="modal-footer">' +
 							'<button type="button" class="btn btn-danger button-rejectappeal" data-uuid="' + item.proposalUuid + '">[[#{button.rejectAppeal}]]</button>' +
-							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>' +
+							'<button type="button" id="cancelstart" class="btn btn-default" data-dismiss="modal">[[#{button.cancel}]]</button>' +
 						'</div>' +
 					'</div>' +
 				'</div>' +

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/register.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/register.html
@@ -260,6 +260,10 @@
 			            	value: "[[${itemClassFilter}]]"
 		            });
 				}
+				aoData.push({
+					name: "statusFilter",
+					value: "valid,superseded,retired,invalid"
+				});
 	        },
 // 			"fnServerData" : datatable2Rest,
 			"sPaginationType": "bs_normal",

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/conv_details.html
@@ -106,7 +106,9 @@
 				</thead>
 				<tbody th:unless="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
-						<td th:text="${parameterValue.parameterName}"></td>
+						<td>
+							<a th:href="@{__${basePath}__/item/__${parameterValue.parameter.uuid}__}" target="_blank"><span th:text="${parameterValue.parameterName}"></span></a> <span class="text-muted" th:text="'[' + ${parameterValue.parameter.identifier} + ']'"></span>
+						</td>
 						<td>
 							<div class="form-group">
 								<input type="text" class="form-control required" th:value="${parameterValue.value}" th:disabled="!${isProposal}" th:readonly="!${isProposal}" th:required="${isProposal}"/>
@@ -120,7 +122,7 @@
 				<tbody th:if="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
 						<td>
-							<span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span>
+							<a th:href="@{__${basePath}__/item/__${parameterValue.parameter.referencedItemUuid}__}" target="_blank"><span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span></a>
 							<input type="hidden" th:name="'parameterValues[' + ${row.index} + '].parameter.referencedItemUuid'" th:value="${parameterValue.parameter.referencedItemUuid}"/>
 						</td>
 						<td>
@@ -207,7 +209,7 @@
             	.done(function (data) {
             		$.each(data, function(idx, item) {
         				table.fnAddData([
-        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
+        					"<a href='[[@{__${basePath}__/item/}]]" + item[0] + "' target='_blank'><span>" + item[2] + "</span></a><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
         					"<div class='form-group'><input type='text' class='form-control input-sm col-md-12' name='parameterValues[" + idx + "].value' required='required'/></div>",
     						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].parameterUnit.referencedItemUuid' required='required' style='width: 100%'/>"
 						]);

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/trans_details.html
@@ -123,7 +123,9 @@
 				</thead>
 				<tbody th:unless="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
-						<td th:text="${parameterValue.parameterName}"></td>
+						<td>
+							<a th:href="@{__${basePath}__/item/__${parameterValue.parameter.uuid}__}" target="_blank"><span th:text="${parameterValue.parameterName}"></span></a> <span class="text-muted" th:text="'[' + ${parameterValue.parameter.identifier} + ']'"></span>
+						</td>
 						<td>
 							<input type="hidden" th:id="'paramValueType_' + ${row.index}" th:attr="data-index=${row.index}" class="select-paramtype" th:value="${parameterValue.parameterType}" readonly="readonly" style="width: 100%"/>
 						</td>
@@ -144,7 +146,7 @@
 				<tbody th:if="${isProposal}">
 					<tr th:each="parameterValue,row : *{parameterValues}">
 						<td>
-							<span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span>
+							<a th:href="@{__${basePath}__/item/__${parameterValue.parameter.referencedItemUuid}__}" target="_blank"><span th:text="${@dataController.getParameterName(parameterValue.parameter.referencedItemUuid).body.name}"></span></a>
 							<input type="hidden" th:name="'parameterValues[' + ${row.index} + '].parameter.referencedItemUuid'" th:value="${parameterValue.parameter.referencedItemUuid}"/>
 						</td>
 						<td>
@@ -288,7 +290,7 @@
             	.done(function (data) {
             		$.each(data, function(idx, item) {
         				table.fnAddData([
-        					"<span>" + item[2] + "</span><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
+        					"<a href='[[@{__${basePath}__/item/}]]" + item[0] + "' target='_blank'><span>" + item[2] + "</span></a><input type='hidden' name='parameterValues[" + idx + "].parameter.referencedItemUuid' value='" + item[0] + "'/>",
         					"<input type='hidden' id='paramValueType_" + idx + "' data-index='" + idx + "' class='select-paramtype' name='parameterValues[" + idx + "].parameterType' value='MEASURE' required='required' style='width: 100%'/>",
         					"<div class='form-group'><input type='text' class='form-control input-sm col-md-12' name='parameterValues[" + idx + "].value' required='required'/></div>",
     						"<input type='hidden' class='form-control' id='parameterUom_" + idx + "' name='parameterValues[" + idx + "].parameterUnit.referencedItemUuid' required='required' style='width: 100%'/>",


### PR DESCRIPTION
Adds back-end support for filtering the list of contained register items and makes invalidated items accessible both via the list of contained register items and various endpoints (e.g. direct access via the item identifier). Resolves #70.

Also fixes the Cancel button in JavaScript-generated popups, resolves #72.

Also makes operation parameter names in the parameter table clickable, resolves #74.

