### PR TITLE
Add ObjectUsage migration for operations and other changes

### DIFF
--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/IsoProposalServiceImpl.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/IsoProposalServiceImpl.java
@@ -236,12 +236,12 @@ public class IsoProposalServiceImpl extends ProposalServiceImpl implements IsoPr
 	
 	private void assignItemIdentifier(Addition addition) {
 		RE_RegisterItem proposedItem = addition.getItem();
+		Integer identifier = this.findNextAvailableIdentifier();
+		proposedItem.setItemIdentifier(BigInteger.valueOf(identifier.longValue()));
 		if (proposedItem instanceof IdentifiedItem) {
-			Integer identifier = this.findNextAvailableIdentifier();
 			((IdentifiedItem)proposedItem).setIdentifier(identifier);
-			proposedItem.setItemIdentifier(BigInteger.valueOf(identifier.longValue()));
-			logger.debug(">>> Assigned identifier {} to item '{}'", identifier, proposedItem.getName());
 		}
+		logger.debug(">>> Assigned identifier {} to item '{}'", identifier, proposedItem.getName());
 	}
 
 	@Override
@@ -336,8 +336,8 @@ public class IsoProposalServiceImpl extends ProposalServiceImpl implements IsoPr
 	
 	@Override
 	public Integer findNextAvailableIdentifier() {
-		String jpql = "SELECT MAX(i.identifier) FROM IdentifiedItem i";
-		Integer maxCode = (Integer)entityManager.createQuery(jpql).getResultList().get(0);
-		return (maxCode == null || maxCode < 1) ? 1 : maxCode + 1;
+		String jpql = "SELECT MAX(i.itemIdentifier) FROM RE_RegisterItem i";
+		BigInteger maxCode = (BigInteger)entityManager.createQuery(jpql).getResultList().get(0);
+		return (maxCode == null || maxCode.intValueExact() < 1) ? 1 : maxCode.intValueExact() + 1;
 	}
 }

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/RegistryFixService.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/RegistryFixService.java
@@ -1,20 +1,57 @@
 package org.iso.registry.api.registry;
 
+import static org.mockito.Matchers.*;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
 import javax.transaction.Transactional;
 
+import org.iso.registry.api.initialization.IsoRegistryInitializer;
+import org.iso.registry.api.registry.registers.gcp.ExtentDTO;
+import org.iso.registry.api.registry.registers.gcp.ExtentItemProposalDTO;
+import org.iso.registry.core.model.ObjectDomain;
+import org.iso.registry.core.model.iso19115.extent.EX_GeographicBoundingBox;
+import org.iso.registry.core.model.iso19115.extent.ExtentItem;
+import org.iso.registry.core.model.operation.SingleOperationItem;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
 
+import de.bespire.LoggerFactory;
+import de.geoinfoffm.registry.api.OrganizationService;
+import de.geoinfoffm.registry.api.ProposalService;
 import de.geoinfoffm.registry.api.RegisterService;
+import de.geoinfoffm.registry.core.model.Addition;
+import de.geoinfoffm.registry.core.model.Organization;
+import de.geoinfoffm.registry.core.model.Proposal;
+import de.geoinfoffm.registry.core.model.ProposalType;
+import de.geoinfoffm.registry.core.model.iso19135.InvalidProposalException;
 import de.geoinfoffm.registry.core.model.iso19135.RE_ItemClass;
 import de.geoinfoffm.registry.core.model.iso19135.RE_Register;
+import de.geoinfoffm.registry.core.model.iso19135.RE_RegisterItem;
+import de.geoinfoffm.registry.core.model.iso19135.RE_SubmittingOrganization;
 import de.geoinfoffm.registry.persistence.ItemClassRepository;
+import de.geoinfoffm.registry.persistence.RegisterItemRepository;
 import de.geoinfoffm.registry.persistence.RegisterRepository;
 
 @Transactional
 @Service
 public class RegistryFixService
 {
+	private static final Logger logger = LoggerFactory.make();
+
 	@Autowired
 	private ItemClassRepository itemClassRepository;
 
@@ -22,7 +59,19 @@ public class RegistryFixService
 	private RegisterRepository registerRepository;
 
 	@Autowired
+	private RegisterItemRepository itemRepository;
+
+	@Autowired
 	private RegisterService registerService;
+
+	@Autowired
+	private OrganizationService orgService;
+
+	@Autowired
+	private ProposalService proposalService;
+
+	@PersistenceContext
+	private EntityManager entityManager;
 
 	public void createExtentItemClass(StringBuilder log) {
 		log.append("Attempting to add item class 'Extent' to ISO Geodetic Register...\n");
@@ -48,5 +97,238 @@ public class RegistryFixService
 		else {
 			log.append(">>> Item class 'Extent' already contained, aborting.\n");
 		}
+	}
+
+	/**
+	 * Migrates the extents associated with Conversion and Transformation items to the new Object Domain
+	 * mechanism introduced with ISO 19111:2019.
+	 * 
+	 * The migration workflow checks if an item was already migrated before. If a "domain" does already
+	 * exist, the item is skipped.
+	 * 
+	 * If the extent of the item is already registered or has been seen previously in the current migration
+	 * run, that extent is reused if it has the exact same definition as the existing/seen extent. If the
+	 * definitions do not match, the operation item is skipped.
+	 * 
+	 * If an extent is neither already registered and was not seen before, an Addition proposal is created
+	 * for it. All proposals are collected in a proposal group (one per migrated item class).
+	 * 
+	 * Finally, the "domain" attribute of every migrated operation item is populated with the item's
+	 * "scope" and a reference to the created/reused extent item.
+	 * 
+	 * @param log Log shown in the front-end
+	 */
+	public void migrateCoordinateOperationExtents(StringBuilder log) {
+		log.append("Migrating domains of validity for Coordinate Operation items...\n");
+
+		RE_Register geodeticRegister = registerRepository.findByName("ISO Geodetic Register");
+		Assert.notNull(geodeticRegister, "ISO Geodetic Register not found");
+
+		RE_ItemClass convItemClass = itemClassRepository.findByName("Conversion");
+		Assert.notNull(convItemClass, "Item class 'Conversion' not found");
+
+		RE_ItemClass transformationItemClass = itemClassRepository.findByName("Transformation");
+		Assert.notNull(transformationItemClass, "Item class 'Transformation' not found");
+
+		RE_ItemClass extentItemClass = itemClassRepository.findByName("Extent");
+		Assert.notNull(extentItemClass, "Item class 'Extent' not found");
+
+		Organization isotc211 = orgService.findByName(IsoRegistryInitializer.ISO_REGISTRY_CONTROLBODY_ORG_NAME);
+		Assert.notNull(isotc211, MessageFormat.format("Control body organization \"{0}\" not found", 
+				IsoRegistryInitializer.ISO_REGISTRY_CONTROLBODY_ORG_NAME));
+
+		Map<String, UUID> extentItems = new HashMap<>();
+		Map<String, ExtentDTO> extents = new HashMap<>();
+
+		try {
+			migrateOperationItems(convItemClass, extentItemClass, geodeticRegister, isotc211, extentItems, extents, log);
+			migrateOperationItems(transformationItemClass, extentItemClass, geodeticRegister, isotc211, extentItems, extents, log);
+		}
+		catch (Throwable t) {
+			logger.error(t.getMessage(), t);
+			log.append("Uncaught exception while applying fix: " + t.getMessage());
+		}
+	}
+
+	@SuppressWarnings("deprecation")
+	private void migrateOperationItems(RE_ItemClass operationItemClass, RE_ItemClass extentItemClass, RE_Register geodeticRegister,
+			Organization sponsor, Map<String, UUID> extentItemsCache, Map<String, ExtentDTO> extentsCache, StringBuilder log) {
+
+		Set<RE_RegisterItem> opItems = new HashSet<>();
+		opItems.addAll(itemRepository.findByItemClass(operationItemClass));
+
+		List<RE_RegisterItem> skippedItems = new ArrayList<>();
+		List<Proposal> proposals = new ArrayList<>();
+		for (RE_RegisterItem opItem : opItems) {
+			SingleOperationItem operation = (SingleOperationItem)opItem;
+			log.append(MessageFormat.format("\nConverting {0} \"{1}\" ({2})...\n", operationItemClass.getName(), operation.getName(),
+					operation.getUuid()));
+
+			if (!operation.getDomains().isEmpty()) {
+				log.append("!!! skipping as it already has at least one domain.\n");
+				skippedItems.add(opItem);
+				continue;
+			}
+			else if (operation.getScope().isEmpty()) {
+				log.append("!!! skipping as it has no scope. Please migrate manually!\n");
+				skippedItems.add(opItem);
+				continue;
+			}
+			else if (operation.getScope().size() > 1) {
+				log.append("!!! skipping as it has more than one scope. Please migrate manually!\n");
+				skippedItems.add(opItem);
+				continue;
+			}
+
+			ExtentItem extentItem;
+			String extentDescription = operation.getDomainOfValidity().getDescription();
+			ExtentDTO operationExtent = new ExtentDTO(operation.getDomainOfValidity());
+
+			if (extentItemsCache.containsKey(extentDescription)) {
+				ExtentDTO cachedExtent = extentsCache.get(extentDescription);
+				if (!compareExtents(cachedExtent, operationExtent)) {
+					log.append(MessageFormat.format("!!! Extent \"{0}\" was seen with different definition before, skipping!\n",
+							extentDescription));
+					skippedItems.add(opItem);
+					continue;
+				}
+
+				extentItem = (ExtentItem)itemRepository.findOne(extentItemsCache.get(extentDescription));
+				log.append(MessageFormat.format(">>> reusing extent \"{0}\"\n", extentDescription));
+			}
+			else {
+				// Try to find existing extent item that matches the description
+				String jpql = "SELECT i FROM ExtentItem i WHERE i.name = :extentName";
+				TypedQuery<ExtentItem> query = entityManager.createQuery(jpql, ExtentItem.class);
+				query.setParameter("extentName", extentDescription);
+				List<ExtentItem> existingExtents = query.getResultList();
+
+				if (existingExtents != null && !existingExtents.isEmpty()) {
+					if (existingExtents.size() == 1) {
+						extentItem = existingExtents.get(0);
+						ExtentDTO itemExtent = new ExtentDTO(extentItem.getExtent());
+						if (!compareExtents(itemExtent, operationExtent)) {
+							log.append(MessageFormat.format("!!! Extent \"{0}\" exists in register with different definition, skipping\n",
+									extentDescription));
+							skippedItems.add(opItem);
+							continue;
+						}
+
+						extentItemsCache.put(extentDescription, extentItem.getUuid());
+						extentsCache.put(extentDescription, new ExtentDTO(extentItem.getExtent()));
+						log.append(MessageFormat.format(">>> reusing extent \"{0}\"\n", extentDescription));
+					}
+					else {
+						log.append(MessageFormat.format("!!! more than existing extent with name \"{0}\" found, skipping\n", 
+								extentDescription));
+						skippedItems.add(opItem);
+						continue;
+					}
+				}
+				else {
+					// If there is no extent item yet, propose it
+					ExtentItemProposalDTO proposalDto = createExtentItemProposal(operation, geodeticRegister, extentItemClass,
+							sponsor.getSubmittingOrganization(), log);
+
+					Addition addition;
+					try {
+						addition = proposalService.createAdditionProposal(proposalDto);
+						proposals.add(addition);
+					}
+					catch (InvalidProposalException e) {
+						log.append("!!! Failed to create addition proposal: " + e.getMessage());
+						logger.error(e.getMessage(), e);
+						skippedItems.add(opItem);
+						continue;
+					}
+
+					log.append(MessageFormat.format(">>> created Extent proposal \"{0}\"\n", addition.getTitle()));
+					extentItem = (ExtentItem)addition.getItem();
+
+					extentItemsCache.put(extentDescription, extentItem.getUuid());
+					extentsCache.put(extentDescription, new ExtentDTO(extentItem.getExtent()));
+				}
+			}
+
+			ObjectDomain domain = new ObjectDomain(operation.getScope().get(0), extentItem);
+			operation.setDomains(Arrays.asList(domain));
+			operation = itemRepository.save(operation);
+
+			log.append(MessageFormat.format(">>> created domain with scope \"{0}\" and extent \"{1}\"\n",
+					operation.getName(), extentItem.getName()));
+		}
+
+		try {
+			proposalService.createProposalGroup("Creation of Extent items for migration of " + operationItemClass.getName() + "s",
+					proposals, sponsor.getSubmittingOrganization());
+		}
+		catch (InvalidProposalException e) {
+			log.append(MessageFormat.format("!!! Failed to create proposal group: {0}\n\n", e.getMessage()));
+			logger.error(e.getMessage(), e);
+		}
+
+		if (skippedItems.isEmpty()) {
+			log.append(MessageFormat.format("\n\nAll {0} items were migrated succesfully.", operationItemClass.getName()));
+		}
+		else {
+			log.append("\n\n!!! The following items were skipped, please migrate manually:\n");
+			for (RE_RegisterItem skippedItem : skippedItems) {
+				log.append(MessageFormat.format("- {0} {1} ({2})\n", skippedItem.getItemClass().getName(), skippedItem.getItemIdentifier(),
+						skippedItem.getName()));
+			}
+		}
+	}
+
+	private boolean compareExtents(ExtentDTO first, ExtentDTO second) {
+		boolean isIdentical = true;
+		if (first.getGeographicBoundingBoxes().size() != second.getGeographicBoundingBoxes().size()) {
+			isIdentical = false;
+		}
+		else {
+			List<EX_GeographicBoundingBox> cachedBoxes = first.getGeographicBoundingBoxes();
+			List<EX_GeographicBoundingBox> operationBoxes = second.getGeographicBoundingBoxes();
+
+			for (EX_GeographicBoundingBox cachedBox : cachedBoxes) {
+				boolean foundBox = false;
+				for (EX_GeographicBoundingBox operationBox : operationBoxes) {
+					if (operationBox.getEastBoundLongitude().equals(cachedBox.getEastBoundLongitude())
+						&& operationBox.getNorthBoundLatitude().equals(cachedBox.getNorthBoundLatitude())
+						&& operationBox.getSouthBoundLatitude().equals(cachedBox.getSouthBoundLatitude())
+						&& operationBox.getWestBoundLongitude().equals(cachedBox.getWestBoundLongitude())) {
+
+						foundBox = true;
+						break;
+					}
+				}
+
+				if (!foundBox) {
+					isIdentical = false;
+					break;
+				}
+			}
+		}
+		return isIdentical;
+	}
+
+	@SuppressWarnings("deprecation")
+	private ExtentItemProposalDTO createExtentItemProposal(SingleOperationItem operation, RE_Register targetRegister,
+			RE_ItemClass extentItemClass, RE_SubmittingOrganization sponsor, StringBuilder log) {
+
+		ExtentDTO domainOfValidity = new ExtentDTO(operation.getDomainOfValidity());
+
+		String migrationNote = MessageFormat.format("Created as part of the ISO 19111:2019 migration of {0} \"{1}\"",
+				operation.getItemClass().getName(), operation.getName());
+
+		ExtentItemProposalDTO extentItemProposal = new ExtentItemProposalDTO();
+		extentItemProposal.setControlBodyNotes(migrationNote);
+		extentItemProposal.setGeographicBoundingBoxes(domainOfValidity.getGeographicBoundingBoxes());
+		extentItemProposal.setItemClassUuid(extentItemClass.getUuid());
+		extentItemProposal.setJustification(migrationNote);
+		extentItemProposal.setName(domainOfValidity.getDescription());
+		extentItemProposal.setProposalType(ProposalType.ADDITION);
+		extentItemProposal.setSponsorUuid(sponsor.getUuid());
+		extentItemProposal.setTargetRegisterUuid(targetRegister.getUuid());
+
+		return extentItemProposal;
 	}
 }

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/FixController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/FixController.java
@@ -167,6 +167,9 @@ public class FixController extends AbstractController
 					case "create-extent-item-class":
 						fixer.createExtentItemClass(initLog);
 						break;
+					case "migrate-operations":
+						fixer.migrateCoordinateOperationExtents(initLog);
+						break;
 					default:
 						message = String.format("Unknown fix: '%s'", fix);
 						initLog.append(message);

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/ProposalsController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/ProposalsController.java
@@ -484,6 +484,17 @@ public class ProposalsController extends AbstractController
 			
 			return "redirect:/registry/proposal/edit_supersession"; 
 		}
+		else if (proposal instanceof ProposalGroup) {
+			ProposalGroup group = (ProposalGroup)proposal;
+			proposalService.updateProposalGroup(group, group.getProposals(), proposalDto.getName());
+
+			if (allParams.containsKey("redirectTo")) {
+				return "redirect:" + allParams.get("redirectTo");
+			}
+			else {
+				return "redirect:/management/" + role;
+			}
+		}
 		else {
 			proposalDto = bindAdditionalAttributes(proposalDto, servletRequest, itemClassRepository, itemClassRegistry, conversionService);
 

--- a/src/iso-registry-client/src/main/resources/i18n/messages.xml
+++ b/src/iso-registry-client/src/main/resources/i18n/messages.xml
@@ -390,6 +390,7 @@
 	
 	<entry key="form.label.itemClass">Item class</entry>
 	<entry key="form.label.targetRegister">Target register</entry>
+	<entry key="form.label.groupName">Group name</entry>
 	<entry key="form.label.name">Name</entry>
 	<entry key="form.label.definition">Definition</entry>
 	<entry key="form.label.description">Description</entry>
@@ -513,6 +514,7 @@
 	
 	<entry key="form.help.cannotDeleteOrganization">There are still users associated with this organization. Please reassign all users of this organization before deleting it.</entry>
 	
+	<entry key="form.placeholder.groupName"></entry>
 	<entry key="form.placeholder.name"></entry>
 	<entry key="form.placeholder.definition"></entry>
 	<entry key="form.placeholder.description"></entry>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/admin/fixes.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/admin/fixes.html
@@ -85,6 +85,11 @@
 									<td>Add Extent item class</td>
 									<td><a class="btn btn-default" th:href="@{__${basePath}__/fix/create-extent-item-class}" th:text="#{button.applyFix}" /></td>
 								</tr>
+								<tr>
+									<td><a href="https://github.com/ISO-TC211/iso-geodetic-registry/issues/51">#51 (iso-geodetic-registry)</a></td>
+									<td>Migrate Coordinate Operation items to ISO 19111:2019</td>
+									<td><a class="btn btn-default" th:href="@{__${basePath}__/fix/migrate-operations}" th:text="#{button.applyFix}" /></td>
+								</tr>
 							</tbody>
 						</table>
 					</div>

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals-lists.html
@@ -188,7 +188,7 @@
 				'</div>' +
 			'</div>';
 		
-		result = result.replace('\{0\}', item.name);
+		result = result.replace('\{0\}', item.title);
 		
 		return result;
 	};

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/globals.html
@@ -596,6 +596,7 @@
 					<thead>
 						<tr>
 							<th th:text="#{tableheader.scope}" />
+							<th th:text="#{tableheader.description}" />
 							<th th:text="#{form.label.northernLatitude}" />
 							<th th:text="#{form.label.easternLongitude}" />
 							<th th:text="#{form.label.southernLatitude}" />
@@ -606,6 +607,7 @@
 						<th:block th:each="domain : *{domains}">
 							<tr th:each="gbb,iterStat : ${domain.domainOfValidity.geographicBoundingBoxes}">
 								<td th:if="${iterStat.first}" th:rowspan="${domain.domainOfValidity.geographicBoundingBoxes.size()}" th:text="${domain.scope}" />
+								<td th:text="${domain.domainOfValidity.name}" />
 								<td th:text="${gbb.northBoundLatitude}" />
 								<td th:text="${gbb.eastBoundLongitude}" />
 								<td th:text="${gbb.southBoundLatitude}" />

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/submitter.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/mgmt/submitter.html
@@ -25,6 +25,7 @@
 					<div style="padding: 10px">
 						<div class="control-group" style="margin-top: 10px; margin-bottom: 10px">
 							<button id="proposeNew" class="btn btn-success" data-toggle="modal" href="#addNewItem" th:text="#{button.addition}">Item registrieren</button>
+							<button id="createGroup" class="btn btn-default" data-toggle="modal" href="#createProposalGroup" th:text="#{button.createGroup}"/>
 
 								<div class="modal fade" th:id="addNewItem" role="dialog">
 									<div class="modal-dialog">
@@ -68,7 +69,23 @@
 									</div>
 								</div>
 
-
+							<div class="modal fade" id="createProposalGroup" role="dialog">
+								<div class="modal-dialog">
+									<div class="modal-content">
+										<div class="modal-header">
+											<h4 th:text="#{popup.createGroup.header}"/>
+										</div>
+										<div class="modal-body">
+											<label class="control-label" for="groupName" th:text="#{form.label.groupName}"/>
+											<input id="groupName" name="groupName" th:placeholder="#{form.placeholder.groupName}" class="form-control" required="required"></input>
+										</div>
+										<div class="modal-footer">
+											<button type="button" id="creategroup" class="btn btn-success button-creategroup" th:text="#{button.createGroup}"/>
+											<button type="button" id="cancelaccept" class="btn btn-default" data-dismiss="modal" th:text="#{button.cancel}">Abbrechen</button>
+										</div>
+									</div>
+								</div>
+							</div>
 						</div>
 						<table id="proposalsTable" class="datatable table table-striped">
 							<thead>


### PR DESCRIPTION
A migration workflow for Conversion and Transformation items is implemented and made available via the registry fixes framework. The workflow migrates existing domains of validity and scopes to the new "Object Usage" mechanism introduced in ISO 19111:2019.

Also changes the way `itemIdentifier`s and, for `IdentifiedItems`, the `identifier` is calculated and assigned. The new assignment algorithm is centered around `RE_RegisterItem`'s `itemIdentifier` which is available in all item classes.

Also adds methods and GUI to manually create proposal groups from the submitter view.