### PR TITLE
Prefill superseding item with data from superseded item

### DIFF
--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/IdentifiedItemProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/IdentifiedItemProposalDTO.java
@@ -253,6 +253,10 @@ public class IdentifiedItemProposalDTO extends RegisterItemProposalDTO
 		}
 	}
 
+	protected static boolean hasReferencedItem(RegisterItemProposalDTO dto) {
+		return dto != null && dto.getReferencedItemUuid() != null;
+	}
+
 //	public String getNameCodespace() {
 //		return nameCodespace;
 //	}

--- a/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/crs/CoordinateReferenceSystemItemProposalDTO.java
+++ b/src/iso-registry-api/src/main/java/org/iso/registry/api/registry/registers/gcp/crs/CoordinateReferenceSystemItemProposalDTO.java
@@ -252,24 +252,21 @@ public class CoordinateReferenceSystemItemProposalDTO extends ReferenceSystemIte
 				item.setDomainOfValidity(itemExtent);
 			}
 			
-			if (this.getCoordinateSystem() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
+			if (hasReferencedItem(this.getCoordinateSystem()) && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
 				SingleCoordinateReferenceSystemItem<?> singleCrs = (SingleCoordinateReferenceSystemItem<?>)registerItem;
 				CoordinateSystemItem cs = entityManager.find(CoordinateSystemItem.class, this.getCoordinateSystem().getReferencedItemUuid());
 				singleCrs.setCoordinateSystem(cs);
 			}
 			
-			if (this.getDatum() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
+			if (hasReferencedItem(this.getDatum()) && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
 				SingleCoordinateReferenceSystemItem<DatumItem> singleCrs = (SingleCoordinateReferenceSystemItem<DatumItem>)registerItem;
 				DatumItem datum = entityManager.find(DatumItem.class, this.getDatum().getReferencedItemUuid());
 				singleCrs.setDatum(datum);
 			}
 			
-			if (this.getSourceCrs() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
+			if (hasReferencedItem(this.getSourceCrs()) && (registerItem instanceof SingleCoordinateReferenceSystemItem<?>)) {
 				SingleCoordinateReferenceSystemItem<DatumItem> singleCrs = (SingleCoordinateReferenceSystemItem<DatumItem>)registerItem;
 				CoordinateReferenceSystemItem crs = entityManager.find(CoordinateReferenceSystemItem.class, this.getSourceCrs().getReferencedItemUuid());
-				if (crs == null) {
-					new Object();
-				}
 //				if (crs instanceof SingleCoordinateReferenceSystemItem<?>) {
 //					singleCrs.setBaseCrs((SingleCoordinateReferenceSystemItem<DatumItem>)crs);
 //				}
@@ -278,7 +275,7 @@ public class CoordinateReferenceSystemItemProposalDTO extends ReferenceSystemIte
 //				}
 			}
 			
-			if (this.getHorizontalCrs() != null && (registerItem instanceof CompoundCoordinateReferenceSystemItem)) {
+			if (hasReferencedItem(this.getHorizontalCrs()) && (registerItem instanceof CompoundCoordinateReferenceSystemItem)) {
 				// By convention, the first CRS is the horizontal component
 				CompoundCoordinateReferenceSystemItem compoundCrs = (CompoundCoordinateReferenceSystemItem)registerItem;
 				CoordinateReferenceSystemItem horizontalCrs = entityManager.find(CoordinateReferenceSystemItem.class, this.getHorizontalCrs().getReferencedItemUuid());
@@ -290,7 +287,7 @@ public class CoordinateReferenceSystemItemProposalDTO extends ReferenceSystemIte
 					throw new RuntimeException(String.format("Illegal CRS used as part of Compound CRS: %d is not a Single CRS", horizontalCrs.getIdentifier()));
 				}
 			}
-			if (this.getVerticalCrs() != null && (registerItem instanceof CompoundCoordinateReferenceSystemItem)) {
+			if (hasReferencedItem(this.getVerticalCrs()) && (registerItem instanceof CompoundCoordinateReferenceSystemItem)) {
 				// By convention, the second CRS is the vertical component
 				CompoundCoordinateReferenceSystemItem compoundCrs = (CompoundCoordinateReferenceSystemItem)registerItem;
 				CoordinateReferenceSystemItem verticalCrs = entityManager.find(CoordinateReferenceSystemItem.class, this.getVerticalCrs().getReferencedItemUuid());
@@ -302,13 +299,13 @@ public class CoordinateReferenceSystemItemProposalDTO extends ReferenceSystemIte
 				}
 			}
 			
-			if (this.getBaseCrs() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem)) {
+			if (hasReferencedItem(this.getBaseCrs()) && this.getBaseCrs().getReferencedItemUuid() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem)) {
 				SingleCoordinateReferenceSystemItem singleCrs = (SingleCoordinateReferenceSystemItem)registerItem;
 				SingleCoordinateReferenceSystemItem baseCrs = entityManager.find(SingleCoordinateReferenceSystemItem.class, this.getBaseCrs().getReferencedItemUuid());
 				singleCrs.setBaseCrs(baseCrs);
 			}
 			
-			if (this.getOperation() != null && (registerItem instanceof SingleCoordinateReferenceSystemItem)) {
+			if (hasReferencedItem(this.getOperation()) && (registerItem instanceof SingleCoordinateReferenceSystemItem)) {
 				SingleCoordinateReferenceSystemItem singleCrs = (SingleCoordinateReferenceSystemItem)registerItem;
 				SingleOperationItem operation = entityManager.find(SingleOperationItem.class, this.getOperation().getReferencedItemUuid());
 				singleCrs.setOperation(operation);

--- a/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/ProposalsController.java
+++ b/src/iso-registry-client/src/main/java/org/iso/registry/client/controller/registry/ProposalsController.java
@@ -3,10 +3,7 @@
  */
 package org.iso.registry.client.controller.registry;
 
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.CONTROLBODY_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.MANAGER_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.OWNER_ROLE_PREFIX;
-import static de.geoinfoffm.registry.core.security.RegistrySecurity.SUBMITTER_ROLE_PREFIX;
+import static de.geoinfoffm.registry.core.security.RegistrySecurity.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
When creating a supersession, until now all information of the new items that are to supersede the original had to be entered. With this patch, the dialog for creating the superseding items will be prefilled with the details from the superseded item.

Closes #82 