### PR TITLE
Fixes for the information source modal popup

### DIFF
--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel.html
@@ -90,7 +90,7 @@
 					<div th:if="!${isProposal}" class="modal-body" th:object="${item.informationSource[__${rowstat.index}__]}">
 						<div th:include="registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(${rowstat.index})"/>
 					</div>
-					<div th:if="${isProposal} and !${isReadOnly}" class="modal-body" th:object="${proposal.informationSource[__${rowstat.index}__]}" th:with="isReadOnly='true'">
+					<div th:if="${isProposal}" class="modal-body" th:object="${proposal.informationSource[__${rowstat.index}__]}" th:with="isReadOnly='true'">
 						<div th:include="registry/registers/gcp/infosrc_panel_content :: informationSourcePanelContent(${rowstat.index})"/>
 					</div>
 					<div class="modal-footer">

--- a/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel_content.html
+++ b/src/iso-registry-client/src/main/webapp/WEB-INF/views/registry/registers/gcp/infosrc_panel_content.html
@@ -72,9 +72,9 @@
 			<div class="form-group col-md-12">
 				<div th:replace="globals :: formLabel('alternateTitle-' + ${rowStat.index}, #{form.label.alternateTitle})"/>
 				<div class="input-group">
-					<input th:if="${isProposal}" th:name="'informationSource[__${index}__].alternateTitle[' + ${rowStat.index} + ']'" th:value="${altTitle}" class="form-control"/>
-					<span th:unless="${isProposal}" class="text-muted" th:text="${rowStat.index + 1} + '.'"></span>&nbsp;<big th:unless="${isProposal}" th:text="${altTitle}"/>
-					<span class="input-group-btn" th:if="${isProposal}">
+					<input th:if="${isProposal} and !${isReadOnly}" th:name="'informationSource[__${index}__].alternateTitle[' + ${rowStat.index} + ']'" th:value="${altTitle}" class="form-control"/>
+					<span th:unless="${isProposal} and !${isReadOnly}" class="text-muted" th:text="${rowStat.index + 1} + '.'"></span>&nbsp;<big th:unless="${isProposal} and !${isReadOnly}" th:text="${altTitle}"/>
+					<span class="input-group-btn" th:if="${isProposal} and !${isReadOnly}">
 						<button type="button" class="btn btn-default button-delete-alt-title" th:id="'delete-alt-title-' + ${rowStat.index}"><span class="glyphicon glyphicon-remove"/></button>
 					</span>
 				</div>


### PR DESCRIPTION
- show information source details if the proposal details view is in read-only mode
- make sure that no editable controls are shown in the popup if proposal details view is in read-only mode

closes #95