### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -47,7 +47,7 @@ jobs:
       #                prerelease: false
 
 
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           dockerfile: Dockerfile
           tags: "latest,${{env.TAG_NAME}}"


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore